### PR TITLE
feat: add email service infrastructure

### DIFF
--- a/BreastCancer.csproj
+++ b/BreastCancer.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MailKit" Version="4.14.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />

--- a/Controllers/EmailController.cs
+++ b/Controllers/EmailController.cs
@@ -1,0 +1,24 @@
+﻿using BreastCancer.DTO.request;
+using BreastCancer.Service.Interface;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BreastCancer.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class EmailController : ControllerBase
+    {
+        private readonly IEmailService _emailService;
+        public EmailController(IEmailService emailService)
+        {
+            _emailService = emailService;
+        }
+
+        [HttpPost]
+        public async Task SendEmail([FromBody] SendEmailDTO emailDTO) // For testing purposes
+        {
+            await _emailService.SendEmailAsync(emailDTO.RecipientEmail, emailDTO.Subject, emailDTO.Body);
+        }
+    }
+}

--- a/DTO/request/SendEmailDTO.cs
+++ b/DTO/request/SendEmailDTO.cs
@@ -1,0 +1,9 @@
+﻿namespace BreastCancer.DTO.request
+{
+    public class SendEmailDTO
+    {
+        public string RecipientEmail { get; set; } = string.Empty;
+        public string Subject { get; set; } = string.Empty;
+        public string Body { get; set; } = string.Empty;
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -25,7 +25,7 @@ namespace BreastCancer
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
 
-            // add Identity
+            #region Identity 
             builder.Services.AddIdentity<ApplicationUser, ApplicationRole>(options =>
             {
                 // Password Setting
@@ -43,6 +43,7 @@ namespace BreastCancer
                 options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(5);
 
             }).AddEntityFrameworkStores<BreastCancerDB>();
+            #endregion
 
             builder.Services.AddDbContext<BreastCancerDB>(options =>
             {
@@ -58,6 +59,7 @@ namespace BreastCancer
             builder.Services.AddScoped<IDoctorRepository, DoctorRepository>();
             builder.Services.AddScoped<ICaregiverRepository, CaregiverRepository>();
             builder.Services.AddScoped<ICaregiverService, CaregiverService>();
+            builder.Services.AddScoped<IEmailService, EmailService>();
 
             #region Swagger
             builder.Services.AddSwaggerGen(c =>

--- a/Service/Implementation/EmailService.cs
+++ b/Service/Implementation/EmailService.cs
@@ -1,0 +1,51 @@
+﻿using BreastCancer.Service.Interface;
+using System.Net.Mail;
+using System.Net;
+
+namespace BreastCancer.Service.Implementation
+{
+    public class EmailService : IEmailService
+    {
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<EmailService> _logger;
+
+        public EmailService(IConfiguration configuration, ILogger<EmailService> logger)
+        {
+            _configuration = configuration;
+            this._logger = logger;
+        }
+        public async Task SendEmailAsync(string recipient, string subject, string body)
+        {
+            try
+            {
+                IConfigurationSection smtpSettings = _configuration.GetSection("SmtpSettings");
+
+                using MailMessage mailMessage = new()
+                {
+                    From = new MailAddress(smtpSettings["Username"]!),
+                    Subject = subject,
+                    Body = body,
+                    IsBodyHtml = true
+                };
+
+                mailMessage.To.Add(recipient);
+
+                using SmtpClient smtpClient = new(smtpSettings["Server"])
+                {
+                    Port = int.Parse(smtpSettings["Port"]!),
+                    Credentials = new NetworkCredential(smtpSettings["Username"], smtpSettings["Password"]),
+                    EnableSsl = bool.Parse(smtpSettings["EnableSsl"]!)
+                };
+
+                await smtpClient.SendMailAsync(mailMessage);
+
+                _logger.LogInformation("Email successfully sent to {Recipient}", recipient);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to send email to {Recipient}", recipient);
+                throw; 
+            }
+        }
+    }
+}

--- a/Service/Interface/IEmailService.cs
+++ b/Service/Interface/IEmailService.cs
@@ -1,0 +1,7 @@
+﻿namespace BreastCancer.Service.Interface
+{
+    public interface IEmailService
+    {
+        Task SendEmailAsync(string recipient, string subject, string body);
+    }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -13,6 +13,13 @@
     "MetadataAddress": "http://keycloak:8080/realms/breast-cancer-realm/.well-known/openid-configuration",
     "RequireHttpsMetadata": false
   },
+  "SmtpSettings": {
+    "Server": "smtp.gmail.com",
+    "Port": 587,
+    "EnableSsl": true,
+    "Username": "mahmoud.smtp.test@gmail.com",
+    "Password": "msip weic qenr vias"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
Introduced EmailService and IEmailService for sending emails via SMTP, including a new EmailController and SendEmailDTO for API integration. Registered the service in DI, added MailKit dependency, and configured SMTP settings in appsettings.json.