### PR TITLE
feat: Create and Update Treatment Plan & Dynamic Medicine Scheduling

### DIFF
--- a/Context/BreastCancerDB.cs
+++ b/Context/BreastCancerDB.cs
@@ -87,6 +87,31 @@ namespace BreastCancer.Context
                 new ApplicationRole { Id = "3", Name = "Doctor", NormalizedName = "DOCTOR" },
                 new ApplicationRole { Id = "4", Name = "Caregiver", NormalizedName = "CAREGIVER" }
             );
+
+            // TreatmentPlan relationships
+            modelBuilder.Entity<TreatmentPlan>()
+                .HasOne(tp => tp.Patient)
+                .WithMany()
+                .HasForeignKey(tp => tp.PatientId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            modelBuilder.Entity<TreatmentPlan>()
+                .HasOne(tp => tp.Doctor)
+                .WithMany()
+                .HasForeignKey(tp => tp.DoctorId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            modelBuilder.Entity<TreatmentPlan>()
+                .HasMany(tp => tp.Medicines)
+                .WithOne(m => m.TreatmentPlan)
+                .HasForeignKey(m => m.TreatmentPlanId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<Medicine>()
+                .HasOne(m => m.TreatmentPlan)
+                .WithMany(tp => tp.Medicines)
+                .HasForeignKey(m => m.TreatmentPlanId)
+                .OnDelete(DeleteBehavior.Cascade);
         }
 
     }

--- a/Controllers/TreatmentPlanController.cs
+++ b/Controllers/TreatmentPlanController.cs
@@ -26,7 +26,7 @@ namespace BreastCancer.Controllers
         }
 
         [HttpPost]
-        [Authorize(Roles = "Patient, Admin")]
+        [Authorize(Roles = "Patient, Admin, Doctor")]
         [SwaggerOperation(Summary = "Create a new treatment plan")]
         [SwaggerResponse(StatusCodes.Status201Created, "Treatment plan created successfully")]
         [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid treatment plan data or validation errors")]
@@ -67,7 +67,7 @@ namespace BreastCancer.Controllers
         }
 
         [HttpPut("{id}")]
-        [Authorize(Roles = "Patient, Admin")]
+        [Authorize(Roles = "Patient, Admin, Doctor")]
         [SwaggerOperation(Summary = "Update an existing treatment plan")]
         [SwaggerResponse(StatusCodes.Status200OK, "Treatment plan updated successfully")]
         [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid treatment plan data or validation errors")]
@@ -115,7 +115,7 @@ namespace BreastCancer.Controllers
         }
 
         [HttpPost("medicines/{medicineId}/mark-taken")]
-        [Authorize(Roles = "Patient, Admin")]
+        [Authorize(Roles = "Patient")]
         [SwaggerOperation(Summary = "Mark a medicine as taken")]
         [SwaggerResponse(StatusCodes.Status200OK, "Medicine marked as taken successfully with updated NextAlert")]
         [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid operation (e.g., medicine has ended)")]

--- a/Controllers/TreatmentPlanController.cs
+++ b/Controllers/TreatmentPlanController.cs
@@ -1,0 +1,152 @@
+using BreastCancer.DTO.request;
+using BreastCancer.DTO.response;
+using BreastCancer.Service.Interface;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using System.Security.Claims;
+
+namespace BreastCancer.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    [Authorize]
+    public class TreatmentPlanController : ControllerBase
+    {
+        private readonly ITreatmentPlanService _treatmentPlanService;
+        private readonly ILogger<TreatmentPlanController> _logger;
+
+        public TreatmentPlanController(
+            ITreatmentPlanService treatmentPlanService,
+            ILogger<TreatmentPlanController> logger)
+        {
+            _treatmentPlanService = treatmentPlanService;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Create a new treatment plan
+        /// </summary>
+        /// <param name="treatmentPlanDto">Treatment plan creation data including medicines</param>
+        /// <returns>Created treatment plan with medicines</returns>
+        /// <remarks>
+        /// Creates a new treatment plan for the authenticated patient. 
+        /// The patient ID is automatically extracted from the JWT token.
+        /// Requires at least one medicine to be added to the plan.
+        /// Doctor information can be provided either by DoctorId (if doctor exists in system) or DoctorName (for manual entry).
+        /// Medicines will have their initial NextAlert set to StartTime. After the user marks a medicine as taken, 
+        /// the NextAlert will be recalculated as LastTaken + IntervalHours.
+        /// </remarks>
+        [HttpPost]
+        [Authorize(Roles = "Patient, Admin")]
+        [SwaggerOperation(Summary = "Create a new treatment plan")]
+        [SwaggerResponse(StatusCodes.Status201Created, "Treatment plan created successfully")]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid treatment plan data or validation errors")]
+        [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized access")]
+        [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - User does not have required role")]
+        public async Task<IActionResult> CreateTreatmentPlan([FromBody] TreatmentPlanCreateDTO treatmentPlanDto)
+        {
+            try
+            {
+                if (!ModelState.IsValid)
+                {
+                    return BadRequest(ModelState);
+                }
+
+                // Get patient ID from JWT token claims
+                var patientId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+                if (string.IsNullOrEmpty(patientId))
+                {
+                    return Unauthorized(new { message = "Unable to identify patient from token." });
+                }
+
+                var createdPlan = await _treatmentPlanService.CreateTreatmentPlanAsync(patientId, treatmentPlanDto);
+                return CreatedAtAction(
+                    nameof(CreateTreatmentPlan),
+                    new { id = createdPlan.Id },
+                    createdPlan);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Invalid operation while creating treatment plan");
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error creating treatment plan");
+                return BadRequest(new { message = "An error occurred while creating the treatment plan." });
+            }
+        }
+
+        /// <summary>
+        /// Update an existing treatment plan
+        /// </summary>
+        /// <param name="id">Treatment plan ID</param>
+        /// <param name="treatmentPlanDto">Treatment plan update data</param>
+        /// <returns>Updated treatment plan with medicines</returns>
+        /// <remarks>
+        /// Updates an existing treatment plan. Only provided properties will be updated (null/empty values are ignored).
+        /// Patients can only update their own treatment plans.
+        /// 
+        /// **Medicine Updates:**
+        /// - Medicines with an `Id` will be updated (only non-null properties)
+        /// - Medicines without an `Id` will be created as new medicines
+        /// - Existing medicines not included in the `Medicines` array will be deleted
+        /// 
+        /// **Dynamic Medicine Scheduling:**
+        /// - When updating a medicine's `LastTaken` property, the `NextAlert` will be automatically recalculated as `LastTaken + IntervalHours`
+        /// - If `IntervalHours` is updated and `LastTaken` exists, `NextAlert` will be recalculated with the new interval
+        /// - If the calculated `NextAlert` exceeds the medicine's `EndTime`, `NextAlert` will be set to null (no more alerts)
+        /// 
+        /// **Note:** This endpoint uses partial update - only send the fields you want to update.
+        /// </remarks>
+        [HttpPut("{id}")]
+        [Authorize(Roles = "Patient, Admin")]
+        [SwaggerOperation(Summary = "Update an existing treatment plan")]
+        [SwaggerResponse(StatusCodes.Status200OK, "Treatment plan updated successfully")]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid treatment plan data or validation errors")]
+        [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized access")]
+        [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - User does not have required role or does not own the treatment plan")]
+        [SwaggerResponse(StatusCodes.Status404NotFound, "Treatment plan not found")]
+        public async Task<IActionResult> UpdateTreatmentPlan(int id, [FromBody] TreatmentPlanUpdateDTO treatmentPlanDto)
+        {
+            try
+            {
+                if (!ModelState.IsValid)
+                {
+                    return BadRequest(ModelState);
+                }
+
+                // Get patient ID from JWT token claims
+                var patientId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+                if (string.IsNullOrEmpty(patientId))
+                {
+                    return Unauthorized(new { message = "Unable to identify patient from token." });
+                }
+
+                var updatedPlan = await _treatmentPlanService.UpdateTreatmentPlanAsync(id, patientId, treatmentPlanDto);
+                return Ok(updatedPlan);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Invalid operation while updating treatment plan");
+                if (ex.Message.Contains("not found"))
+                {
+                    return NotFound(new { message = ex.Message });
+                }
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogWarning(ex, "Unauthorized access attempt to update treatment plan");
+                return Forbid();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error updating treatment plan");
+                return BadRequest(new { message = "An error occurred while updating the treatment plan." });
+            }
+        }
+    }
+}

--- a/Controllers/TreatmentPlanController.cs
+++ b/Controllers/TreatmentPlanController.cs
@@ -93,13 +93,6 @@ namespace BreastCancer.Controllers
         /// - Medicines with an `Id` will be updated (only non-null properties)
         /// - Medicines without an `Id` will be created as new medicines
         /// - Existing medicines not included in the `Medicines` array will be deleted
-        /// 
-        /// **Dynamic Medicine Scheduling:**
-        /// - When updating a medicine's `LastTaken` property, the `NextAlert` will be automatically recalculated as `LastTaken + IntervalHours`
-        /// - If `IntervalHours` is updated and `LastTaken` exists, `NextAlert` will be recalculated with the new interval
-        /// - If the calculated `NextAlert` exceeds the medicine's `EndTime`, `NextAlert` will be set to null (no more alerts)
-        /// 
-        /// **Note:** This endpoint uses partial update - only send the fields you want to update.
         /// </remarks>
         [HttpPut("{id}")]
         [Authorize(Roles = "Patient, Admin")]
@@ -146,6 +139,60 @@ namespace BreastCancer.Controllers
             {
                 _logger.LogError(ex, "Error updating treatment plan");
                 return BadRequest(new { message = "An error occurred while updating the treatment plan." });
+            }
+        }
+
+        /// <summary>
+        /// Mark a medicine as taken
+        /// </summary>
+        /// <param name="medicineId">Medicine ID</param>
+        /// <returns>Updated medicine with recalculated NextAlert</returns>
+        /// <remarks>
+        /// Marks a medicine as taken when the user clicks the "Take Medicine" button.
+        /// **Example:**
+        /// If the interval is 8 hours, but the user was late and took the medicine at 10:00 AM, 
+        /// the next alert will be set to 6:00 PM (not based on the original schedule, but on the actual event).
+        /// </remarks>
+        [HttpPost("medicines/{medicineId}/mark-taken")]
+        [Authorize(Roles = "Patient, Admin")]
+        [SwaggerOperation(Summary = "Mark a medicine as taken")]
+        [SwaggerResponse(StatusCodes.Status200OK, "Medicine marked as taken successfully with updated NextAlert")]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid operation (e.g., medicine has ended)")]
+        [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized access")]
+        [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - User does not have required role or does not own the treatment plan")]
+        [SwaggerResponse(StatusCodes.Status404NotFound, "Medicine not found")]
+        public async Task<IActionResult> MarkMedicineAsTaken(int medicineId)
+        {
+            try
+            {
+                // Get patient ID from JWT token claims
+                var patientId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+                if (string.IsNullOrEmpty(patientId))
+                {
+                    return Unauthorized(new { message = "Unable to identify patient from token." });
+                }
+
+                var updatedMedicine = await _treatmentPlanService.MarkMedicineAsTakenAsync(medicineId, patientId);
+                return Ok(updatedMedicine);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Invalid operation while marking medicine as taken");
+                if (ex.Message.Contains("not found"))
+                {
+                    return NotFound(new { message = ex.Message });
+                }
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogWarning(ex, "Unauthorized access attempt to mark medicine as taken");
+                return Forbid();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error marking medicine as taken");
+                return BadRequest(new { message = "An error occurred while marking the medicine as taken." });
             }
         }
     }

--- a/Controllers/TreatmentPlanController.cs
+++ b/Controllers/TreatmentPlanController.cs
@@ -25,19 +25,6 @@ namespace BreastCancer.Controllers
             _logger = logger;
         }
 
-        /// <summary>
-        /// Create a new treatment plan
-        /// </summary>
-        /// <param name="treatmentPlanDto">Treatment plan creation data including medicines</param>
-        /// <returns>Created treatment plan with medicines</returns>
-        /// <remarks>
-        /// Creates a new treatment plan for the authenticated patient. 
-        /// The patient ID is automatically extracted from the JWT token.
-        /// Requires at least one medicine to be added to the plan.
-        /// Doctor information can be provided either by DoctorId (if doctor exists in system) or DoctorName (for manual entry).
-        /// Medicines will have their initial NextAlert set to StartTime. After the user marks a medicine as taken, 
-        /// the NextAlert will be recalculated as LastTaken + IntervalHours.
-        /// </remarks>
         [HttpPost]
         [Authorize(Roles = "Patient, Admin")]
         [SwaggerOperation(Summary = "Create a new treatment plan")]
@@ -79,21 +66,6 @@ namespace BreastCancer.Controllers
             }
         }
 
-        /// <summary>
-        /// Update an existing treatment plan
-        /// </summary>
-        /// <param name="id">Treatment plan ID</param>
-        /// <param name="treatmentPlanDto">Treatment plan update data</param>
-        /// <returns>Updated treatment plan with medicines</returns>
-        /// <remarks>
-        /// Updates an existing treatment plan. Only provided properties will be updated (null/empty values are ignored).
-        /// Patients can only update their own treatment plans.
-        /// 
-        /// **Medicine Updates:**
-        /// - Medicines with an `Id` will be updated (only non-null properties)
-        /// - Medicines without an `Id` will be created as new medicines
-        /// - Existing medicines not included in the `Medicines` array will be deleted
-        /// </remarks>
         [HttpPut("{id}")]
         [Authorize(Roles = "Patient, Admin")]
         [SwaggerOperation(Summary = "Update an existing treatment plan")]
@@ -142,17 +114,6 @@ namespace BreastCancer.Controllers
             }
         }
 
-        /// <summary>
-        /// Mark a medicine as taken
-        /// </summary>
-        /// <param name="medicineId">Medicine ID</param>
-        /// <returns>Updated medicine with recalculated NextAlert</returns>
-        /// <remarks>
-        /// Marks a medicine as taken when the user clicks the "Take Medicine" button.
-        /// **Example:**
-        /// If the interval is 8 hours, but the user was late and took the medicine at 10:00 AM, 
-        /// the next alert will be set to 6:00 PM (not based on the original schedule, but on the actual event).
-        /// </remarks>
         [HttpPost("medicines/{medicineId}/mark-taken")]
         [Authorize(Roles = "Patient, Admin")]
         [SwaggerOperation(Summary = "Mark a medicine as taken")]

--- a/DTO/request/MedicineCreateDTO.cs
+++ b/DTO/request/MedicineCreateDTO.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BreastCancer.DTO.request
+{
+    public class MedicineCreateDTO
+    {
+        [Required]
+        [MaxLength(100)]
+        public string Name { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(500)]
+        public string Instructions { get; set; } = string.Empty;
+
+        [Required]
+        public DateTime StartTime { get; set; }
+
+        [Required]
+        [Range(1, 24)]
+        public int IntervalHours { get; set; }
+    }
+}
+

--- a/DTO/request/MedicineUpdateDTO.cs
+++ b/DTO/request/MedicineUpdateDTO.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BreastCancer.DTO.request
+{
+    public class MedicineUpdateDTO
+    {
+        public int? Id { get; set; } // If provided, update existing medicine; if null, create new
+
+        [MaxLength(100)]
+        public string? Name { get; set; }
+
+        [MaxLength(500)]
+        public string? Instructions { get; set; }
+
+        public DateTime? StartTime { get; set; }
+
+        [Range(1, 24)]
+        public int? IntervalHours { get; set; }
+
+        public DateTime? EndTime { get; set; }
+
+        public DateTime? LastTaken { get; set; } // When medicine is marked as taken - will trigger NextAlert recalculation
+    }
+}
+

--- a/DTO/request/TreatmentPlanCreateDTO.cs
+++ b/DTO/request/TreatmentPlanCreateDTO.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BreastCancer.DTO.request
+{
+    public class TreatmentPlanCreateDTO
+    {
+        [Required]
+        [MaxLength(100)]
+        public string Name { get; set; } = string.Empty;
+
+        [MaxLength(500)]
+        public string? Description { get; set; }
+
+        [MaxLength(100)]
+        public string? DoctorName { get; set; }
+
+        public string? DoctorId { get; set; }
+
+        [Required]
+        public DateTime StartDate { get; set; }
+
+        public DateTime? EndDate { get; set; }
+
+        [Required]
+        [MinLength(1, ErrorMessage = "At least one medicine is required")]
+        public List<MedicineCreateDTO> Medicines { get; set; } = new List<MedicineCreateDTO>();
+
+        public string? PrescriptionImageUrl { get; set; } // For future file upload support
+    }
+}
+

--- a/DTO/request/TreatmentPlanUpdateDTO.cs
+++ b/DTO/request/TreatmentPlanUpdateDTO.cs
@@ -1,0 +1,30 @@
+using BreastCancer.Enum;
+using System.ComponentModel.DataAnnotations;
+
+namespace BreastCancer.DTO.request
+{
+    public class TreatmentPlanUpdateDTO
+    {
+        [MaxLength(100)]
+        public string? Name { get; set; }
+
+        [MaxLength(500)]
+        public string? Description { get; set; }
+
+        [MaxLength(100)]
+        public string? DoctorName { get; set; }
+
+        public string? DoctorId { get; set; }
+
+        public DateTime? StartDate { get; set; }
+
+        public DateTime? EndDate { get; set; }
+
+        public TreatmentPlanStatus? Status { get; set; }
+
+        public List<MedicineUpdateDTO>? Medicines { get; set; }
+
+        public string? PrescriptionImageUrl { get; set; }
+    }
+}
+

--- a/DTO/response/MedicineResponseDTO.cs
+++ b/DTO/response/MedicineResponseDTO.cs
@@ -1,0 +1,17 @@
+namespace BreastCancer.DTO.response
+{
+    public class MedicineResponseDTO
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Instructions { get; set; }
+        public DateTime StartTime { get; set; }
+        public int IntervalHours { get; set; }
+        public DateTime? EndTime { get; set; }
+        public DateTime? LastTaken { get; set; }
+        public DateTime? NextAlert { get; set; }
+        public int TreatmentPlanId { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}
+

--- a/DTO/response/TreatmentPlanResponseDTO.cs
+++ b/DTO/response/TreatmentPlanResponseDTO.cs
@@ -1,0 +1,21 @@
+using BreastCancer.Enum;
+
+namespace BreastCancer.DTO.response
+{
+    public class TreatmentPlanResponseDTO
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public string? DoctorName { get; set; }
+        public string? DoctorId { get; set; }
+        public DateTime StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+        public TreatmentPlanStatus Status { get; set; }
+        public string PatientId { get; set; } = string.Empty;
+        public List<MedicineResponseDTO> Medicines { get; set; } = new List<MedicineResponseDTO>();
+        public DateTime CreatedAt { get; set; }
+        public DateTime? UpdatedAt { get; set; }
+    }
+}
+

--- a/Mapping/MappingProfile.cs
+++ b/Mapping/MappingProfile.cs
@@ -121,6 +121,75 @@ namespace BreastCancer.Mapping
             .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
 
             #endregion
+
+            #region TreatmentPlan Mapping
+
+            // Map TreatmentPlanCreateDTO to TreatmentPlan
+            CreateMap<TreatmentPlanCreateDTO, TreatmentPlan>()
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.PatientId, opt => opt.Ignore())
+                .ForMember(dest => dest.Patient, opt => opt.Ignore())
+                .ForMember(dest => dest.Doctor, opt => opt.Ignore())
+                .ForMember(dest => dest.Status, opt => opt.Ignore())
+                .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.CreatedBy, opt => opt.Ignore())
+                .ForMember(dest => dest.UpdatedBy, opt => opt.Ignore())
+                .ForMember(dest => dest.History, opt => opt.Ignore());
+
+            // Map MedicineCreateDTO to Medicine
+            CreateMap<MedicineCreateDTO, Medicine>()
+                .ForMember(dest => dest.Instruction, opt => opt.MapFrom(src => src.Instructions))
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.TreatmentPlanId, opt => opt.Ignore())
+                .ForMember(dest => dest.TreatmentPlan, opt => opt.Ignore())
+                .ForMember(dest => dest.EndTime, opt => opt.Ignore())
+                .ForMember(dest => dest.LastTaken, opt => opt.Ignore())
+                .ForMember(dest => dest.NextAlert, opt => opt.Ignore())
+                .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.CreatedBy, opt => opt.Ignore())
+                .ForMember(dest => dest.UpdatedBy, opt => opt.Ignore());
+
+            // Map TreatmentPlan to TreatmentPlanResponseDTO
+            CreateMap<TreatmentPlan, TreatmentPlanResponseDTO>()
+                .ForMember(dest => dest.DoctorName, opt => opt.MapFrom(src => 
+                    !string.IsNullOrEmpty(src.DoctorId) && src.Doctor != null && src.Doctor.User != null
+                        ? src.Doctor.User.FullName 
+                        : src.DoctorName));
+
+            // Map Medicine to MedicineResponseDTO
+            CreateMap<Medicine, MedicineResponseDTO>()
+                .ForMember(dest => dest.Instructions, opt => opt.MapFrom(src => src.Instruction));
+
+            // Map TreatmentPlanUpdateDTO to TreatmentPlan
+            CreateMap<TreatmentPlanUpdateDTO, TreatmentPlan>()
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.PatientId, opt => opt.Ignore())
+                .ForMember(dest => dest.Patient, opt => opt.Ignore())
+                .ForMember(dest => dest.Doctor, opt => opt.Ignore())
+                .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.CreatedBy, opt => opt.Ignore())
+                .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.UpdatedBy, opt => opt.Ignore())
+                .ForMember(dest => dest.History, opt => opt.Ignore())
+                .ForMember(dest => dest.Medicines, opt => opt.Ignore())
+                .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
+
+            // Map MedicineUpdateDTO to Medicine
+            CreateMap<MedicineUpdateDTO, Medicine>()
+                .ForMember(dest => dest.Instruction, opt => opt.MapFrom(src => src.Instructions))
+                .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id ?? 0))
+                .ForMember(dest => dest.TreatmentPlanId, opt => opt.Ignore())
+                .ForMember(dest => dest.TreatmentPlan, opt => opt.Ignore())
+                .ForMember(dest => dest.NextAlert, opt => opt.Ignore()) // Will be recalculated in service when LastTaken is updated
+                .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.CreatedBy, opt => opt.Ignore())
+                .ForMember(dest => dest.UpdatedBy, opt => opt.Ignore())
+                .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
+
+            #endregion
         }
     }
 }

--- a/Models/Medicine.cs
+++ b/Models/Medicine.cs
@@ -19,9 +19,14 @@ namespace BreastCancer.Models
         [Required]
         public DateTime StartTime { get; set; }
         
+        [Required]
+        public int IntervalHours { get; set; } // Hours between doses
+        
         public DateTime? EndTime { get; set; }
         
         public DateTime? LastTaken { get; set; }
+        
+        public DateTime? NextAlert { get; set; } // Calculated next alert time
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public string? CreatedBy { get; set; }

--- a/Models/TreatmentPlan.cs
+++ b/Models/TreatmentPlan.cs
@@ -28,9 +28,11 @@ namespace BreastCancer.Models
         public string PatientId { get; set; }
         public virtual Patient Patient { get; set; }
         
-        [Required]
-        public string DoctorId { get; set; }
-        public virtual Doctor Doctor { get; set; }
+        public string? DoctorId { get; set; } // Optional - patient can manually input doctor name
+        public virtual Doctor? Doctor { get; set; }
+        
+        [MaxLength(100)]
+        public string? DoctorName { get; set; } // For manual entry when DoctorId is null
 
         public virtual ICollection<Medicine> Medicines { get; set; } = new List<Medicine>();
         public virtual ICollection<TreatmentPlanHistory> History { get; set; } = new List<TreatmentPlanHistory>();

--- a/Program.cs
+++ b/Program.cs
@@ -73,12 +73,14 @@ namespace BreastCancer
             builder.Services.AddScoped<IPatientRepository, PatientRepository>();
             builder.Services.AddScoped<IDoctorRepository, DoctorRepository>();
             builder.Services.AddScoped<ICaregiverRepository, CaregiverRepository>();
+            builder.Services.AddScoped<ITreatmentPlanRepository, TreatmentPlanRepository>();
             builder.Services.AddScoped<ICaregiverService, CaregiverService>();
             builder.Services.AddScoped<IAccountService, AccountService>();
             builder.Services.AddScoped<IEmailService, EmailService>();
             builder.Services.AddScoped<IAuthTokenService, AuthTokenService>();
             builder.Services.AddScoped<IPatientService, PatientService>();
             builder.Services.AddScoped<IDoctorService, DoctorService>();
+            builder.Services.AddScoped<ITreatmentPlanService, TreatmentPlanService>();
             builder.Services.AddAutoMapper(cfg =>
             {
                 cfg.AddProfile<MappingProfile>();

--- a/Repository/Interface/ITreatmentPlanRepository.cs
+++ b/Repository/Interface/ITreatmentPlanRepository.cs
@@ -5,6 +5,7 @@ namespace BreastCancer.Repository.Interface
     public interface ITreatmentPlanRepository : IGenericRepository<TreatmentPlan>
     {
         Task<TreatmentPlan?> GetByIdAsync(int id);
+        Task<Medicine?> GetMedicineByIdAsync(int medicineId);
     }
 }
 

--- a/Repository/Interface/ITreatmentPlanRepository.cs
+++ b/Repository/Interface/ITreatmentPlanRepository.cs
@@ -1,0 +1,10 @@
+using BreastCancer.Models;
+
+namespace BreastCancer.Repository.Interface
+{
+    public interface ITreatmentPlanRepository : IGenericRepository<TreatmentPlan>
+    {
+        Task<TreatmentPlan?> GetByIdAsync(int id);
+    }
+}
+

--- a/Repository/Interface/IUnitOfWork.cs
+++ b/Repository/Interface/IUnitOfWork.cs
@@ -5,7 +5,7 @@
         IDoctorRepository DoctorsRepository { get; }
         IPatientRepository PatientsRepository { get; }
         ICaregiverRepository CaregiversRepository { get; }
-
+        ITreatmentPlanRepository TreatmentPlansRepository { get; }
         IRefreshTokenRepository RefreshTokenRepository { get; }
         
 

--- a/Repository/Repositories/TreatmentPlanRepository.cs
+++ b/Repository/Repositories/TreatmentPlanRepository.cs
@@ -13,13 +13,11 @@ namespace BreastCancer.Repository.Repositories
 
         public async Task<TreatmentPlan?> GetByIdAsync(int id)
         {
-            // Rely on EF Core lazy loading proxies to load navigation properties (Medicines, Patient, Doctor)
             return await _dbSet.FirstOrDefaultAsync(tp => tp.Id == id);
         }
 
         public async Task<Medicine?> GetMedicineByIdAsync(int medicineId)
         {
-            // Rely on EF Core lazy loading proxies to load navigation properties (TreatmentPlan)
             var medicines = _Context.Set<Medicine>();
             return await medicines.FirstOrDefaultAsync(m => m.Id == medicineId);
         }

--- a/Repository/Repositories/TreatmentPlanRepository.cs
+++ b/Repository/Repositories/TreatmentPlanRepository.cs
@@ -16,6 +16,13 @@ namespace BreastCancer.Repository.Repositories
             // Rely on EF Core lazy loading proxies to load navigation properties (Medicines, Patient, Doctor)
             return await _dbSet.FirstOrDefaultAsync(tp => tp.Id == id);
         }
+
+        public async Task<Medicine?> GetMedicineByIdAsync(int medicineId)
+        {
+            // Rely on EF Core lazy loading proxies to load navigation properties (TreatmentPlan)
+            var medicines = _Context.Set<Medicine>();
+            return await medicines.FirstOrDefaultAsync(m => m.Id == medicineId);
+        }
     }
 }
 

--- a/Repository/Repositories/TreatmentPlanRepository.cs
+++ b/Repository/Repositories/TreatmentPlanRepository.cs
@@ -1,0 +1,21 @@
+using BreastCancer.Context;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
+using Microsoft.EntityFrameworkCore;
+
+namespace BreastCancer.Repository.Repositories
+{
+    public class TreatmentPlanRepository : GenericRepository<TreatmentPlan>, ITreatmentPlanRepository
+    {
+        public TreatmentPlanRepository(BreastCancerDB context) : base(context)
+        {
+        }
+
+        public async Task<TreatmentPlan?> GetByIdAsync(int id)
+        {
+            // Rely on EF Core lazy loading proxies to load navigation properties (Medicines, Patient, Doctor)
+            return await _dbSet.FirstOrDefaultAsync(tp => tp.Id == id);
+        }
+    }
+}
+

--- a/Repository/Repositories/UnitOfWork.cs
+++ b/Repository/Repositories/UnitOfWork.cs
@@ -11,6 +11,7 @@ namespace BreastCancer.Repository.Repositories
         private IDoctorRepository _doctorsRepository;
         private IPatientRepository _patientsRepository;
         private ICaregiverRepository _caregiversRepository;
+        private ITreatmentPlanRepository _treatmentPlansRepository;
         private IRefreshTokenRepository _refreshTokenRepository;
         public UnitOfWork(BreastCancerDB Context)
         {
@@ -48,6 +49,18 @@ namespace BreastCancer.Repository.Repositories
                     _caregiversRepository = new CaregiverRepository(context);
                 }
                 return _caregiversRepository;
+            }
+        }
+
+        public ITreatmentPlanRepository TreatmentPlansRepository
+        {
+            get
+            {
+                if (_treatmentPlansRepository == null)
+                {
+                    _treatmentPlansRepository = new TreatmentPlanRepository(context);
+                }
+                return _treatmentPlansRepository;
             }
         }
 

--- a/Service/Implementation/TreatmentPlanService.cs
+++ b/Service/Implementation/TreatmentPlanService.cs
@@ -1,0 +1,212 @@
+using AutoMapper;
+using BreastCancer.DTO.request;
+using BreastCancer.DTO.response;
+using BreastCancer.Enum;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
+using BreastCancer.Service.Interface;
+using Microsoft.Extensions.Logging;
+
+namespace BreastCancer.Service.Implementation
+{
+    public class TreatmentPlanService : ITreatmentPlanService
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IMapper _mapper;
+        private readonly ILogger<TreatmentPlanService> _logger;
+
+        public TreatmentPlanService(
+            IUnitOfWork unitOfWork,
+            IMapper mapper,
+            ILogger<TreatmentPlanService> logger)
+        {
+            _unitOfWork = unitOfWork;
+            _mapper = mapper;
+            _logger = logger;
+        }
+
+        public async Task<TreatmentPlanResponseDTO> CreateTreatmentPlanAsync(string patientId, TreatmentPlanCreateDTO treatmentPlanDto)
+        {
+            try
+            {
+                // Validate patient exists
+                var patient = await _unitOfWork.PatientsRepository.GetByIdAsync(patientId);
+                if (patient == null)
+                {
+                    throw new InvalidOperationException($"Patient with ID '{patientId}' not found.");
+                }
+
+                // Validate doctor if DoctorId is provided
+                if (!string.IsNullOrEmpty(treatmentPlanDto.DoctorId))
+                {
+                    var doctor = await _unitOfWork.DoctorsRepository.GetByIdAsync(treatmentPlanDto.DoctorId);
+                    if (doctor == null)
+                    {
+                        throw new InvalidOperationException($"Doctor with ID '{treatmentPlanDto.DoctorId}' not found.");
+                    }
+                }
+
+                // Map DTO to entity
+                var treatmentPlan = _mapper.Map<TreatmentPlan>(treatmentPlanDto);
+                treatmentPlan.PatientId = patientId;
+                treatmentPlan.Status = TreatmentPlanStatus.NotStarted;
+                treatmentPlan.CreatedAt = DateTime.UtcNow;
+
+                // Calculate initial NextAlert for each medicine (set to StartTime)
+                foreach (var medicine in treatmentPlan.Medicines)
+                {
+                    medicine.NextAlert = medicine.StartTime;
+                    medicine.CreatedAt = DateTime.UtcNow;
+                }
+
+                // Add to repository
+                await _unitOfWork.TreatmentPlansRepository.AddAsync(treatmentPlan);
+                await _unitOfWork.SaveAsync();
+
+                // Reload for response - lazy loading will load Medicines automatically
+                var createdPlan = await _unitOfWork.TreatmentPlansRepository.GetByIdAsync(treatmentPlan.Id);
+                return _mapper.Map<TreatmentPlanResponseDTO>(createdPlan ?? treatmentPlan);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error creating treatment plan for patient: {PatientId}", patientId);
+                throw;
+            }
+        }
+
+        public async Task<TreatmentPlanResponseDTO> UpdateTreatmentPlanAsync(int id, string patientId, TreatmentPlanUpdateDTO treatmentPlanDto)
+        {
+            try
+            {
+                // Get existing treatment plan
+                var existingPlan = await _unitOfWork.TreatmentPlansRepository.GetByIdAsync(id);
+                if (existingPlan == null)
+                {
+                    throw new InvalidOperationException($"Treatment plan with ID '{id}' not found.");
+                }
+
+                // Verify patient owns this treatment plan (or is admin)
+                if (existingPlan.PatientId != patientId)
+                {
+                    throw new UnauthorizedAccessException("You do not have permission to update this treatment plan.");
+                }
+
+                // Validate doctor if DoctorId is provided and changed
+                if (!string.IsNullOrEmpty(treatmentPlanDto.DoctorId) && treatmentPlanDto.DoctorId != existingPlan.DoctorId)
+                {
+                    var doctor = await _unitOfWork.DoctorsRepository.GetByIdAsync(treatmentPlanDto.DoctorId);
+                    if (doctor == null)
+                    {
+                        throw new InvalidOperationException($"Doctor with ID '{treatmentPlanDto.DoctorId}' not found.");
+                    }
+                }
+
+                // Use AutoMapper to update only non-null properties
+                _mapper.Map(treatmentPlanDto, existingPlan);
+                
+                existingPlan.UpdatedAt = DateTime.UtcNow;
+                // TODO: Set UpdatedBy from authenticated user context
+
+                // Handle medicines update
+                if (treatmentPlanDto.Medicines != null)
+                {
+                    // Load existing medicines (lazy loading will load them)
+                    var existingMedicines = existingPlan.Medicines.ToList();
+
+                    foreach (var medicineDto in treatmentPlanDto.Medicines)
+                    {
+                        if (medicineDto.Id.HasValue && medicineDto.Id.GetValueOrDefault() > 0)
+                        {
+                            // Update existing medicine using AutoMapper
+                            var medicineId = medicineDto.Id.Value;
+                            var existingMedicine = existingMedicines.FirstOrDefault(m => m.Id == medicineId);
+                            if (existingMedicine != null)
+                            {
+                                // Store previous values to detect changes
+                                var previousLastTaken = existingMedicine.LastTaken;
+                                var previousIntervalHours = existingMedicine.IntervalHours;
+                                
+                                // AutoMapper will only map non-null properties (conditional mapping)
+                                _mapper.Map(medicineDto, existingMedicine);
+                                
+                                // Dynamic scheduling: Recalculate NextAlert if LastTaken or IntervalHours was updated
+                                var lastTakenWasUpdated = medicineDto.LastTaken.HasValue && medicineDto.LastTaken != previousLastTaken;
+                                var intervalWasUpdated = medicineDto.IntervalHours.HasValue && medicineDto.IntervalHours.Value != previousIntervalHours;
+                                
+                                if (lastTakenWasUpdated || intervalWasUpdated)
+                                {
+                                    // Use the updated LastTaken or current time if not provided
+                                    var lastTakenTime = existingMedicine.LastTaken ?? DateTime.UtcNow;
+                                    
+                                    // Check if medicine has ended
+                                    if (existingMedicine.EndTime.HasValue && DateTime.UtcNow > existingMedicine.EndTime.Value)
+                                    {
+                                        existingMedicine.NextAlert = null; // Medicine has ended
+                                    }
+                                    else if (existingMedicine.LastTaken.HasValue)
+                                    {
+                                        // Recalculate NextAlert = LastTaken + IntervalHours
+                                        var nextAlertTime = lastTakenTime.AddHours(existingMedicine.IntervalHours);
+                                        
+                                        // If medicine has an EndTime, ensure NextAlert doesn't exceed it
+                                        if (existingMedicine.EndTime.HasValue && nextAlertTime > existingMedicine.EndTime.Value)
+                                        {
+                                            existingMedicine.NextAlert = null; // No more alerts after end time
+                                        }
+                                        else
+                                        {
+                                            existingMedicine.NextAlert = nextAlertTime;
+                                        }
+                                    }
+                                }
+                                
+                                existingMedicine.UpdatedAt = DateTime.UtcNow;
+                                // TODO: Set UpdatedBy from authenticated user context
+                            }
+                        }
+                        else
+                        {
+                            // Create new medicine using AutoMapper
+                            var newMedicine = _mapper.Map<Medicine>(medicineDto);
+                            newMedicine.TreatmentPlanId = existingPlan.Id;
+                            newMedicine.NextAlert = newMedicine.StartTime;
+                            newMedicine.CreatedAt = DateTime.UtcNow;
+                            // TODO: Set CreatedBy from authenticated user context
+
+                            existingPlan.Medicines.Add(newMedicine);
+                        }
+                    }
+
+                    // Remove medicines that are not in the update DTO
+                    var medicineIdsInDto = treatmentPlanDto.Medicines
+                        .Where(m => m.Id.HasValue && m.Id.GetValueOrDefault() > 0)
+                        .Select(m => m.Id!.Value)
+                        .ToList();
+
+                    var medicinesToDelete = existingMedicines
+                        .Where(m => !medicineIdsInDto.Contains(m.Id))
+                        .ToList();
+
+                    foreach (var medicineToDelete in medicinesToDelete)
+                    {
+                        existingPlan.Medicines.Remove(medicineToDelete);
+                    }
+                }
+
+                // Update entity
+                _unitOfWork.TreatmentPlansRepository.Update(existingPlan);
+                await _unitOfWork.SaveAsync();
+
+                // Reload for response - lazy loading will load Medicines automatically
+                var updatedPlan = await _unitOfWork.TreatmentPlansRepository.GetByIdAsync(id);
+                return _mapper.Map<TreatmentPlanResponseDTO>(updatedPlan ?? existingPlan);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error updating treatment plan with ID: {TreatmentPlanId} for patient: {PatientId}", id, patientId);
+                throw;
+            }
+        }
+    }
+}
+

--- a/Service/Implementation/TreatmentPlanService.cs
+++ b/Service/Implementation/TreatmentPlanService.cs
@@ -29,14 +29,11 @@ namespace BreastCancer.Service.Implementation
         {
             try
             {
-                // Validate patient exists
                 var patient = await _unitOfWork.PatientsRepository.GetByIdAsync(patientId);
                 if (patient == null)
                 {
                     throw new InvalidOperationException($"Patient with ID '{patientId}' not found.");
                 }
-
-                // Validate doctor if DoctorId is provided
                 if (!string.IsNullOrEmpty(treatmentPlanDto.DoctorId))
                 {
                     var doctor = await _unitOfWork.DoctorsRepository.GetByIdAsync(treatmentPlanDto.DoctorId);
@@ -45,25 +42,17 @@ namespace BreastCancer.Service.Implementation
                         throw new InvalidOperationException($"Doctor with ID '{treatmentPlanDto.DoctorId}' not found.");
                     }
                 }
-
-                // Map DTO to entity
                 var treatmentPlan = _mapper.Map<TreatmentPlan>(treatmentPlanDto);
                 treatmentPlan.PatientId = patientId;
                 treatmentPlan.Status = TreatmentPlanStatus.NotStarted;
                 treatmentPlan.CreatedAt = DateTime.UtcNow;
-
-                // Calculate initial NextAlert for each medicine (set to StartTime)
                 foreach (var medicine in treatmentPlan.Medicines)
                 {
                     medicine.NextAlert = medicine.StartTime;
                     medicine.CreatedAt = DateTime.UtcNow;
                 }
-
-                // Add to repository
                 await _unitOfWork.TreatmentPlansRepository.AddAsync(treatmentPlan);
                 await _unitOfWork.SaveAsync();
-
-                // Reload for response - lazy loading will load Medicines automatically
                 var createdPlan = await _unitOfWork.TreatmentPlansRepository.GetByIdAsync(treatmentPlan.Id);
                 return _mapper.Map<TreatmentPlanResponseDTO>(createdPlan ?? treatmentPlan);
             }
@@ -78,20 +67,15 @@ namespace BreastCancer.Service.Implementation
         {
             try
             {
-                // Get existing treatment plan
                 var existingPlan = await _unitOfWork.TreatmentPlansRepository.GetByIdAsync(id);
                 if (existingPlan == null)
                 {
                     throw new InvalidOperationException($"Treatment plan with ID '{id}' not found.");
                 }
-
-                // Verify patient owns this treatment plan (or is admin)
                 if (existingPlan.PatientId != patientId)
                 {
                     throw new UnauthorizedAccessException("You do not have permission to update this treatment plan.");
                 }
-
-                // Validate doctor if DoctorId is provided and changed
                 if (!string.IsNullOrEmpty(treatmentPlanDto.DoctorId) && treatmentPlanDto.DoctorId != existingPlan.DoctorId)
                 {
                     var doctor = await _unitOfWork.DoctorsRepository.GetByIdAsync(treatmentPlanDto.DoctorId);
@@ -100,42 +84,33 @@ namespace BreastCancer.Service.Implementation
                         throw new InvalidOperationException($"Doctor with ID '{treatmentPlanDto.DoctorId}' not found.");
                     }
                 }
-
-                // Use AutoMapper to update only non-null properties
                 _mapper.Map(treatmentPlanDto, existingPlan);
                 
                 existingPlan.UpdatedAt = DateTime.UtcNow;
                 // TODO: Set UpdatedBy from authenticated user context
-
-                // Handle medicines update
                 if (treatmentPlanDto.Medicines != null)
                 {
-                    // Load existing medicines (lazy loading will load them)
                     var existingMedicines = existingPlan.Medicines.ToList();
 
                     foreach (var medicineDto in treatmentPlanDto.Medicines)
                     {
                         if (medicineDto.Id.HasValue && medicineDto.Id.GetValueOrDefault() > 0)
                         {
-                            // Update existing medicine using AutoMapper
                             var medicineId = medicineDto.Id.Value;
                             var existingMedicine = existingMedicines.FirstOrDefault(m => m.Id == medicineId);
                             if (existingMedicine != null)
                             {
-                                // Store previous values to detect changes
                                 var previousLastTaken = existingMedicine.LastTaken;
                                 var previousIntervalHours = existingMedicine.IntervalHours;
                                 
-                                // AutoMapper will only map non-null properties (conditional mapping)
-                                _mapper.Map(medicineDto, existingMedicine);
                                 
-                                // Dynamic scheduling: Recalculate NextAlert if LastTaken or IntervalHours was updated
+                                _mapper.Map(medicineDto, existingMedicine);
+
                                 var lastTakenWasUpdated = medicineDto.LastTaken.HasValue && medicineDto.LastTaken != previousLastTaken;
                                 var intervalWasUpdated = medicineDto.IntervalHours.HasValue && medicineDto.IntervalHours.Value != previousIntervalHours;
                                 
                                 if (lastTakenWasUpdated || intervalWasUpdated)
                                 {
-                                    // Use helper method to recalculate NextAlert
                                     RecalculateNextAlert(existingMedicine);
                                 }
                                 
@@ -145,7 +120,6 @@ namespace BreastCancer.Service.Implementation
                         }
                         else
                         {
-                            // Create new medicine using AutoMapper
                             var newMedicine = _mapper.Map<Medicine>(medicineDto);
                             newMedicine.TreatmentPlanId = existingPlan.Id;
                             newMedicine.NextAlert = newMedicine.StartTime;
@@ -155,8 +129,6 @@ namespace BreastCancer.Service.Implementation
                             existingPlan.Medicines.Add(newMedicine);
                         }
                     }
-
-                    // Remove medicines that are not in the update DTO
                     var medicineIdsInDto = treatmentPlanDto.Medicines
                         .Where(m => m.Id.HasValue && m.Id.GetValueOrDefault() > 0)
                         .Select(m => m.Id!.Value)
@@ -172,11 +144,8 @@ namespace BreastCancer.Service.Implementation
                     }
                 }
 
-                // Update entity
                 _unitOfWork.TreatmentPlansRepository.Update(existingPlan);
                 await _unitOfWork.SaveAsync();
-
-                // Reload for response - lazy loading will load Medicines automatically
                 var updatedPlan = await _unitOfWork.TreatmentPlansRepository.GetByIdAsync(id);
                 return _mapper.Map<TreatmentPlanResponseDTO>(updatedPlan ?? existingPlan);
             }
@@ -191,26 +160,20 @@ namespace BreastCancer.Service.Implementation
         {
             try
             {
-                // Get medicine with its treatment plan
                 var medicine = await _unitOfWork.TreatmentPlansRepository.GetMedicineByIdAsync(medicineId);
                 if (medicine == null)
                 {
                     throw new InvalidOperationException($"Medicine with ID '{medicineId}' not found.");
                 }
-
-                // Verify patient owns the treatment plan
                 if (medicine.TreatmentPlan?.PatientId != patientId)
                 {
                     throw new UnauthorizedAccessException("You do not have permission to mark this medicine as taken.");
                 }
-
-                // Check if medicine has ended
                 if (medicine.EndTime.HasValue && DateTime.UtcNow > medicine.EndTime.Value)
                 {
                     throw new InvalidOperationException($"Medicine '{medicine.Name}' has already ended on {medicine.EndTime.Value:yyyy-MM-dd HH:mm} UTC.");
                 }
 
-                // Record the current timestamp as last_taken
                 var currentTime = DateTime.UtcNow;
                 medicine.LastTaken = currentTime;
 
@@ -245,20 +208,16 @@ namespace BreastCancer.Service.Implementation
 
             var lastTakenTime = medicine.LastTaken.Value;
 
-            // Check if medicine has ended
             if (medicine.EndTime.HasValue && DateTime.UtcNow > medicine.EndTime.Value)
             {
-                medicine.NextAlert = null; // Medicine has ended
+                medicine.NextAlert = null;
                 return;
             }
 
-            // Calculate NextAlert = LastTaken + IntervalHours
             var nextAlertTime = lastTakenTime.AddHours(medicine.IntervalHours);
-
-            // If medicine has an EndTime, ensure NextAlert doesn't exceed it
             if (medicine.EndTime.HasValue && nextAlertTime > medicine.EndTime.Value)
             {
-                medicine.NextAlert = null; // No more alerts after end time
+                medicine.NextAlert = null;
             }
             else
             {

--- a/Service/Implementation/TreatmentPlanService.cs
+++ b/Service/Implementation/TreatmentPlanService.cs
@@ -53,8 +53,7 @@ namespace BreastCancer.Service.Implementation
                 }
                 await _unitOfWork.TreatmentPlansRepository.AddAsync(treatmentPlan);
                 await _unitOfWork.SaveAsync();
-                var createdPlan = await _unitOfWork.TreatmentPlansRepository.GetByIdAsync(treatmentPlan.Id);
-                return _mapper.Map<TreatmentPlanResponseDTO>(createdPlan ?? treatmentPlan);
+                return _mapper.Map<TreatmentPlanResponseDTO>(treatmentPlan);
             }
             catch (Exception ex)
             {
@@ -146,8 +145,7 @@ namespace BreastCancer.Service.Implementation
 
                 _unitOfWork.TreatmentPlansRepository.Update(existingPlan);
                 await _unitOfWork.SaveAsync();
-                var updatedPlan = await _unitOfWork.TreatmentPlansRepository.GetByIdAsync(id);
-                return _mapper.Map<TreatmentPlanResponseDTO>(updatedPlan ?? existingPlan);
+                return _mapper.Map<TreatmentPlanResponseDTO>(existingPlan);
             }
             catch (Exception ex)
             {
@@ -177,16 +175,14 @@ namespace BreastCancer.Service.Implementation
                 var currentTime = DateTime.UtcNow;
                 medicine.LastTaken = currentTime;
 
-                // Dynamically recalculate NextAlert = LastTaken + IntervalHours
+                
                 RecalculateNextAlert(medicine);
 
                 medicine.UpdatedAt = currentTime;
                 // TODO: Set UpdatedBy from authenticated user context
 
-                // Save changes - EF Core change tracking will detect Medicine updates automatically
                 await _unitOfWork.SaveAsync();
 
-                // Return updated medicine
                 return _mapper.Map<MedicineResponseDTO>(medicine);
             }
             catch (Exception ex)
@@ -203,7 +199,7 @@ namespace BreastCancer.Service.Implementation
         {
             if (!medicine.LastTaken.HasValue)
             {
-                return; // Cannot recalculate without LastTaken
+                return;
             }
 
             var lastTakenTime = medicine.LastTaken.Value;
@@ -213,16 +209,7 @@ namespace BreastCancer.Service.Implementation
                 medicine.NextAlert = null;
                 return;
             }
-
-            var nextAlertTime = lastTakenTime.AddHours(medicine.IntervalHours);
-            if (medicine.EndTime.HasValue && nextAlertTime > medicine.EndTime.Value)
-            {
-                medicine.NextAlert = null;
-            }
-            else
-            {
-                medicine.NextAlert = nextAlertTime;
-            }
+            medicine.NextAlert = lastTakenTime.AddHours(medicine.IntervalHours);
         }
     }
 }

--- a/Service/Implementation/TreatmentPlanService.cs
+++ b/Service/Implementation/TreatmentPlanService.cs
@@ -135,29 +135,8 @@ namespace BreastCancer.Service.Implementation
                                 
                                 if (lastTakenWasUpdated || intervalWasUpdated)
                                 {
-                                    // Use the updated LastTaken or current time if not provided
-                                    var lastTakenTime = existingMedicine.LastTaken ?? DateTime.UtcNow;
-                                    
-                                    // Check if medicine has ended
-                                    if (existingMedicine.EndTime.HasValue && DateTime.UtcNow > existingMedicine.EndTime.Value)
-                                    {
-                                        existingMedicine.NextAlert = null; // Medicine has ended
-                                    }
-                                    else if (existingMedicine.LastTaken.HasValue)
-                                    {
-                                        // Recalculate NextAlert = LastTaken + IntervalHours
-                                        var nextAlertTime = lastTakenTime.AddHours(existingMedicine.IntervalHours);
-                                        
-                                        // If medicine has an EndTime, ensure NextAlert doesn't exceed it
-                                        if (existingMedicine.EndTime.HasValue && nextAlertTime > existingMedicine.EndTime.Value)
-                                        {
-                                            existingMedicine.NextAlert = null; // No more alerts after end time
-                                        }
-                                        else
-                                        {
-                                            existingMedicine.NextAlert = nextAlertTime;
-                                        }
-                                    }
+                                    // Use helper method to recalculate NextAlert
+                                    RecalculateNextAlert(existingMedicine);
                                 }
                                 
                                 existingMedicine.UpdatedAt = DateTime.UtcNow;
@@ -205,6 +184,85 @@ namespace BreastCancer.Service.Implementation
             {
                 _logger.LogError(ex, "Error updating treatment plan with ID: {TreatmentPlanId} for patient: {PatientId}", id, patientId);
                 throw;
+            }
+        }
+
+        public async Task<MedicineResponseDTO> MarkMedicineAsTakenAsync(int medicineId, string patientId)
+        {
+            try
+            {
+                // Get medicine with its treatment plan
+                var medicine = await _unitOfWork.TreatmentPlansRepository.GetMedicineByIdAsync(medicineId);
+                if (medicine == null)
+                {
+                    throw new InvalidOperationException($"Medicine with ID '{medicineId}' not found.");
+                }
+
+                // Verify patient owns the treatment plan
+                if (medicine.TreatmentPlan?.PatientId != patientId)
+                {
+                    throw new UnauthorizedAccessException("You do not have permission to mark this medicine as taken.");
+                }
+
+                // Check if medicine has ended
+                if (medicine.EndTime.HasValue && DateTime.UtcNow > medicine.EndTime.Value)
+                {
+                    throw new InvalidOperationException($"Medicine '{medicine.Name}' has already ended on {medicine.EndTime.Value:yyyy-MM-dd HH:mm} UTC.");
+                }
+
+                // Record the current timestamp as last_taken
+                var currentTime = DateTime.UtcNow;
+                medicine.LastTaken = currentTime;
+
+                // Dynamically recalculate NextAlert = LastTaken + IntervalHours
+                RecalculateNextAlert(medicine);
+
+                medicine.UpdatedAt = currentTime;
+                // TODO: Set UpdatedBy from authenticated user context
+
+                // Save changes - EF Core change tracking will detect Medicine updates automatically
+                await _unitOfWork.SaveAsync();
+
+                // Return updated medicine
+                return _mapper.Map<MedicineResponseDTO>(medicine);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error marking medicine {MedicineId} as taken for patient: {PatientId}", medicineId, patientId);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Helper method to recalculate NextAlert based on LastTaken and IntervalHours
+        /// </summary>
+        private void RecalculateNextAlert(Medicine medicine)
+        {
+            if (!medicine.LastTaken.HasValue)
+            {
+                return; // Cannot recalculate without LastTaken
+            }
+
+            var lastTakenTime = medicine.LastTaken.Value;
+
+            // Check if medicine has ended
+            if (medicine.EndTime.HasValue && DateTime.UtcNow > medicine.EndTime.Value)
+            {
+                medicine.NextAlert = null; // Medicine has ended
+                return;
+            }
+
+            // Calculate NextAlert = LastTaken + IntervalHours
+            var nextAlertTime = lastTakenTime.AddHours(medicine.IntervalHours);
+
+            // If medicine has an EndTime, ensure NextAlert doesn't exceed it
+            if (medicine.EndTime.HasValue && nextAlertTime > medicine.EndTime.Value)
+            {
+                medicine.NextAlert = null; // No more alerts after end time
+            }
+            else
+            {
+                medicine.NextAlert = nextAlertTime;
             }
         }
     }

--- a/Service/Interface/ITreatmentPlanService.cs
+++ b/Service/Interface/ITreatmentPlanService.cs
@@ -7,6 +7,7 @@ namespace BreastCancer.Service.Interface
     {
         Task<TreatmentPlanResponseDTO> CreateTreatmentPlanAsync(string patientId, TreatmentPlanCreateDTO treatmentPlanDto);
         Task<TreatmentPlanResponseDTO> UpdateTreatmentPlanAsync(int id, string patientId, TreatmentPlanUpdateDTO treatmentPlanDto);
+        Task<MedicineResponseDTO> MarkMedicineAsTakenAsync(int medicineId, string patientId);
     }
 }
 

--- a/Service/Interface/ITreatmentPlanService.cs
+++ b/Service/Interface/ITreatmentPlanService.cs
@@ -1,0 +1,12 @@
+using BreastCancer.DTO.request;
+using BreastCancer.DTO.response;
+
+namespace BreastCancer.Service.Interface
+{
+    public interface ITreatmentPlanService
+    {
+        Task<TreatmentPlanResponseDTO> CreateTreatmentPlanAsync(string patientId, TreatmentPlanCreateDTO treatmentPlanDto);
+        Task<TreatmentPlanResponseDTO> UpdateTreatmentPlanAsync(int id, string patientId, TreatmentPlanUpdateDTO treatmentPlanDto);
+    }
+}
+


### PR DESCRIPTION
**1. Create Treatment Plan (Header)**
**2. Add Medicines to Plan**
**3. Reminder & Rescheduling Logic**
**First Alert**
Initial NextAlert is set to StartTime when plan is created
Triggered exactly at StartTime
**Mark as Taken**
User can mark medicine as taken when button was clicked
Automatically recalculates next alert based on actual intake time
**Dynamic Next Alert Calculation**
Calculation Rule: Next Alert = last_taken + interval
Uses actual time user clicked button (not original schedule)
Example: If interval is 8 hours, but user was late and took it at 10:00 AM, next alert is 6:00 PM
**Logic Details:**
Detects when LastTaken or IntervalHours is updated
Automatically recalculates NextAlert = LastTaken + IntervalHours
Handles EndTime validation (sets NextAlert = null if exceeds EndTime)
Updates UpdatedAt timestamp