### PR TITLE
feat: add transaction support to UnitOfWork and wrap registration flows

### DIFF
--- a/Repository/Interface/IUnitOfWork.cs
+++ b/Repository/Interface/IUnitOfWork.cs
@@ -1,4 +1,6 @@
-﻿namespace BreastCancer.Repository.Interface
+﻿using Microsoft.EntityFrameworkCore.Storage;
+
+namespace BreastCancer.Repository.Interface
 {
     public interface IUnitOfWork
     {
@@ -7,7 +9,8 @@
         ICaregiverRepository CaregiversRepository { get; }
         ITreatmentPlanRepository TreatmentPlansRepository { get; }
         IRefreshTokenRepository RefreshTokenRepository { get; }
-        
+
+        Task<IDbContextTransaction> BeginTransactionAsync();
 
         Task<int> SaveAsync();
 

--- a/Repository/Repositories/UnitOfWork.cs
+++ b/Repository/Repositories/UnitOfWork.cs
@@ -1,6 +1,8 @@
 ﻿using BreastCancer.Context;
 using BreastCancer.Models;
 using BreastCancer.Repository.Interface;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore;
 
 namespace BreastCancer.Repository.Repositories
 {
@@ -75,6 +77,9 @@ namespace BreastCancer.Repository.Repositories
                 return _refreshTokenRepository;
             }
         }
+
+        public async Task<IDbContextTransaction> BeginTransactionAsync() => await context.Database.BeginTransactionAsync();
+
         public void Save()
         {
             context.SaveChanges();

--- a/Service/Implementation/AccountService.cs
+++ b/Service/Implementation/AccountService.cs
@@ -75,6 +75,8 @@ namespace BreastCancer.Service.Implementation
                 await _unitOfWork.SaveAsync();
                 await transaction.CommitAsync();
 
+                await _emailService.SendEmailAsync(userResult.EmailTo!, "Confirm Your Email Address", userResult.EmailBody!);
+
                 return (true, null);
             }
             catch
@@ -108,6 +110,8 @@ namespace BreastCancer.Service.Implementation
                 await _unitOfWork.SaveAsync();
                 await transaction.CommitAsync();
 
+                await _emailService.SendEmailAsync(userResult.EmailTo!, "Confirm Your Email Address", userResult.EmailBody!);
+
                 return (true, null);
             }
             catch
@@ -138,6 +142,8 @@ namespace BreastCancer.Service.Implementation
                 await _unitOfWork.SaveAsync();
                 await transaction.CommitAsync();
 
+                await _emailService.SendEmailAsync(userResult.EmailTo!, "Confirm Your Email Address", userResult.EmailBody!);
+
                 return (true, null);
             }
             catch
@@ -147,11 +153,11 @@ namespace BreastCancer.Service.Implementation
             }
         }
 
-        private async Task<(string Id, bool IsSuccess, IEnumerable<string> Errors)> CreateUserAsync(BaseRegisterDTO model)
+        private async Task<(string Id, bool IsSuccess, IEnumerable<string> Errors, string? EmailTo, string? EmailBody)> CreateUserAsync(BaseRegisterDTO model)
         {
             var existingUser = await _userManager.FindByEmailAsync(model.Email);
             if (existingUser != null)
-                return (null!, false, new[] { "An account with this email already exists." });
+                return (null!, false, new[] { "An account with this email already exists." }, null, null);
 
             var user = new ApplicationUser
             {
@@ -167,7 +173,7 @@ namespace BreastCancer.Service.Implementation
 
             var result = await _userManager.CreateAsync(user, model.Password);
             if (!result.Succeeded)
-                return (null!, false, result.Errors.Select(e => e.Description));
+                return (null!, false, result.Errors.Select(e => e.Description), null, null);
 
             var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
             user.EmailConfirmationCode = code;
@@ -176,12 +182,11 @@ namespace BreastCancer.Service.Implementation
 
             var roleResult = await _userManager.AddToRoleAsync(user, model.Role);
             if (!roleResult.Succeeded)
-                return (null!, false, roleResult.Errors.Select(e => e.Description));
+                return (null!, false, roleResult.Errors.Select(e => e.Description), null, null);
 
-            var body = EmailTemplates.GetConfirmationEmail(user.FullName, user.EmailConfirmationCode);
-            await _emailService.SendEmailAsync(user.Email!, "Confirm Your Email Address", body);
+            var emailBody = EmailTemplates.GetConfirmationEmail(user.FullName, user.EmailConfirmationCode);
 
-            return (user.Id!, true, null!);
+            return (user.Id!, true, null!, user.Email!, emailBody);
         }
 
         public async Task<TokenResponseDTO> LoginAsync(LoginDTO loginDTO)

--- a/Service/Implementation/AccountService.cs
+++ b/Service/Implementation/AccountService.cs
@@ -55,91 +55,104 @@ namespace BreastCancer.Service.Implementation
 
         public async Task<(bool IsSuccess, IEnumerable<string> Errors)> DoctorRegister(DoctorRegisterDTO DoctorFromRequest)
         {
-
-            var userResult = await CreateUserAsync(DoctorFromRequest);
-
-            if (!userResult.IsSuccess)
+            await using var transaction = await _unitOfWork.BeginTransactionAsync();
+            try
             {
-                return (false, userResult.Errors);
+                var userResult = await CreateUserAsync(DoctorFromRequest);
+                if (!userResult.IsSuccess)
+                    return (false, userResult.Errors);
+
+                var doctor = new Doctor
+                {
+                    UserId = userResult.Id,
+                    LicenseNumber = DoctorFromRequest.LicenseNumber,
+                    Specialization = DoctorFromRequest.Specialization,
+                    YearsOfExperience = DoctorFromRequest.YearsOfExperience,
+                    NationalIdImage = DoctorFromRequest.NationalIdImagePath
+                };
+
+                _unitOfWork.DoctorsRepository.Add(doctor);
+                await _unitOfWork.SaveAsync();
+                await transaction.CommitAsync();
+
+                return (true, null);
             }
-            
-
-            var doctor = new Doctor
+            catch
             {
-                UserId = userResult.Id,
-                LicenseNumber = DoctorFromRequest.LicenseNumber,
-                Specialization = DoctorFromRequest.Specialization,
-                YearsOfExperience = DoctorFromRequest.YearsOfExperience,
-                NationalIdImage = DoctorFromRequest.NationalIdImagePath
-            };
-
-            _unitOfWork.DoctorsRepository.Add(doctor);
-            await _unitOfWork.SaveAsync();
-
-            return (true, null);
+                await transaction.RollbackAsync();
+                throw;
+            }
         }
 
         public async Task<(bool IsSuccess, IEnumerable<string> Errors)> CaregiverRegister(CaregiverRegisterDTO CaregiverFromRequest)
         {
-            var userResult = await CreateUserAsync(CaregiverFromRequest);
-
-            if (!userResult.IsSuccess)
-            {
-                return (false, userResult.Errors);
-            }
-            var Patient = await _unitOfWork.PatientsRepository.GetByEmailAsync(CaregiverFromRequest.PatientEmail);
-
-            if (Patient == null)
+            var patient = await _unitOfWork.PatientsRepository.GetByEmailAsync(CaregiverFromRequest.PatientEmail);
+            if (patient == null)
                 return (false, new[] { "Invalid Email Patient" });
 
-            var caregiver = new Caregiver
+            await using var transaction = await _unitOfWork.BeginTransactionAsync();
+            try
             {
-                UserId = userResult.Id,
-                RelationshipType = CaregiverFromRequest.RelationshipType,
-                PatientId = Patient.UserId
+                var userResult = await CreateUserAsync(CaregiverFromRequest);
+                if (!userResult.IsSuccess)
+                    return (false, userResult.Errors);
 
-            };
+                var caregiver = new Caregiver
+                {
+                    UserId = userResult.Id,
+                    RelationshipType = CaregiverFromRequest.RelationshipType,
+                    PatientId = patient.UserId
+                };
 
-            _unitOfWork.CaregiversRepository.Add(caregiver);
-            await _unitOfWork.SaveAsync();
+                _unitOfWork.CaregiversRepository.Add(caregiver);
+                await _unitOfWork.SaveAsync();
+                await transaction.CommitAsync();
 
-            return (true, null);
-
+                return (true, null);
+            }
+            catch
+            {
+                await transaction.RollbackAsync();
+                throw;
+            }
         }
+
 
         public async Task<(bool IsSuccess, IEnumerable<string> Errors)> PatientRegister(PatientRegisterDTO PatientFromRequest)
         {
-            var userResult = await CreateUserAsync(PatientFromRequest);
-
-            if (!userResult.IsSuccess)
+            await using var transaction = await _unitOfWork.BeginTransactionAsync();
+            try
             {
-                return (false, userResult.Errors);
+                var userResult = await CreateUserAsync(PatientFromRequest);
+                if (!userResult.IsSuccess)
+                    return (false, userResult.Errors);
+
+                var patient = new Patient
+                {
+                    UserId = userResult.Id,
+                    MedicalHistory = PatientFromRequest.MedicalHistory,
+                    DoctorId = null
+                };
+
+                _unitOfWork.PatientsRepository.Add(patient);
+                await _unitOfWork.SaveAsync();
+                await transaction.CommitAsync();
+
+                return (true, null);
             }
-
-            var patient = new Patient
+            catch
             {
-                UserId = userResult.Id,
-                MedicalHistory = PatientFromRequest.MedicalHistory,
-                DoctorId = null // will be assigned later
-
-            };
-
-            _unitOfWork.PatientsRepository.Add(patient);
-            await _unitOfWork.SaveAsync();
-
-            return (true, null);
-
+                await transaction.RollbackAsync();
+                throw;
+            }
         }
 
         private async Task<(string Id, bool IsSuccess, IEnumerable<string> Errors)> CreateUserAsync(BaseRegisterDTO model)
         {
             var existingUser = await _userManager.FindByEmailAsync(model.Email);
-
             if (existingUser != null)
                 return (null!, false, new[] { "An account with this email already exists." });
 
-
-            // ToDo: AutoMapper
             var user = new ApplicationUser
             {
                 FirstName = model.FirstName,
@@ -153,27 +166,20 @@ namespace BreastCancer.Service.Implementation
             };
 
             var result = await _userManager.CreateAsync(user, model.Password);
-
             if (!result.Succeeded)
-                return (null!, false, result.Errors.Select(e => e.Description)!);
+                return (null!, false, result.Errors.Select(e => e.Description));
 
             var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-
             user.EmailConfirmationCode = code;
             user.EmailConfirmationCodeExpireAt = DateTime.UtcNow.AddMinutes(5).ToLocalTime();
-
             await _userManager.UpdateAsync(user);
+
+            var roleResult = await _userManager.AddToRoleAsync(user, model.Role);
+            if (!roleResult.Succeeded)
+                return (null!, false, roleResult.Errors.Select(e => e.Description));
 
             var body = EmailTemplates.GetConfirmationEmail(user.FullName, user.EmailConfirmationCode);
             await _emailService.SendEmailAsync(user.Email!, "Confirm Your Email Address", body);
-
-
-
-            // Assign Role
-            var roleResult = await _userManager.AddToRoleAsync(user, model.Role);
-
-            if (!roleResult.Succeeded)
-                return (null!, false, roleResult.Errors.Select(e => e.Description)!);
 
             return (user.Id!, true, null!);
         }


### PR DESCRIPTION
### What
- Added `BeginTransactionAsync()` to `IUnitOfWork` and implemented it in `UnitOfWork` using EF Core's database transaction.
- Wrapped the three registration flows (`DoctorRegister`, `CaregiverRegister`, `PatientRegister`) in explicit transactions to guarantee that user and profile entities are created atomically.
- Cleaned up `CreateUserAsync`: reordered email sending to occur only after role assignment succeeds, removed redundant null suppression, and standardized variable names.

### Why
- Prevents partial registrations where a user is created but the associated profile or role assignment fails.
- Eliminates manual rollback/cleanup code, reducing error‑prone paths.
- Improves consistency and reliability of multi‑step registration processes.