### PR TITLE
Add Patient unit and integration tests

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -31,7 +31,7 @@ jobs:
           /p:CollectCoverage=true
           /p:CoverletOutput=./TestResults/coverage/
           /p:CoverletOutputFormat=cobertura
-          /p:Threshold=2
+          /p:Threshold=8
           /p:ThresholdType=line
           /p:ThresholdStat=total
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,7 +13,7 @@
         "/p:CollectCoverage=true",
         "/p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage/",
         "/p:CoverletOutputFormat=cobertura",
-        "/p:Threshold=2",
+        "/p:Threshold=8",
         "/p:ThresholdType=line",
         "/p:ThresholdStat=total"
       ],

--- a/BreastCancer.Tests/Integration/PatientControllerIntegrationTests.cs
+++ b/BreastCancer.Tests/Integration/PatientControllerIntegrationTests.cs
@@ -1,0 +1,164 @@
+using System.Net;
+using System.Net.Http.Json;
+using BreastCancer.Controllers;
+using BreastCancer.DTO.request;
+using BreastCancer.DTO.response;
+using BreastCancer.Service.Interface;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BreastCancer.Tests.Integration;
+
+public class PatientControllerIntegrationTests
+{
+    [Fact]
+    public async Task GetAllPatients_ReturnsOk_WhenServiceReturnsPatients()
+    {
+        var fake = new FakePatientService
+        {
+            Patients = new[]
+            {
+                new PatientResponseDTO { Id = "patient-1", Email = "patient1@example.com", FirstName = "Pat", LastName = "One" },
+                new PatientResponseDTO { Id = "patient-2", Email = "patient2@example.com", FirstName = "Pat", LastName = "Two" }
+            }
+        };
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = app.GetTestClient();
+
+        var response = await client.GetAsync("/api/Patient?pageNumber=1&pageSize=10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<PatientResponseDTO[]>();
+        payload.Should().NotBeNull();
+        payload!.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetPatientById_ReturnsNotFound_WhenMissing()
+    {
+        var fake = new FakePatientService();
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = app.GetTestClient();
+
+        var response = await client.GetAsync("/api/Patient/missing");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CreatePatient_ReturnsCreated_WhenValid()
+    {
+        var fake = new FakePatientService
+        {
+            CreatedPatient = new PatientResponseDTO
+            {
+                Id = "patient-1",
+                Email = "patient@example.com",
+                FirstName = "Pat",
+                LastName = "Ient"
+            }
+        };
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync("/api/Patient", new PatientCreateDTO
+        {
+            FirstName = "Pat",
+            LastName = "Ient",
+            Email = "patient@example.com"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var payload = await response.Content.ReadFromJsonAsync<PatientResponseDTO>();
+        payload.Should().NotBeNull();
+        payload!.Id.Should().Be("patient-1");
+    }
+
+    [Fact]
+    public async Task UpdatePatient_ReturnsOk_WhenServiceUpdates()
+    {
+        var fake = new FakePatientService
+        {
+            UpdatedPatient = new PatientResponseDTO
+            {
+                Id = "patient-1",
+                Email = "updated@example.com",
+                FirstName = "Updated",
+                LastName = "User"
+            }
+        };
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = app.GetTestClient();
+
+        var response = await client.PutAsJsonAsync("/api/Patient/patient-1", new PatientUpdateDTO
+        {
+            FirstName = "Updated",
+            Email = "updated@example.com"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<PatientResponseDTO>();
+        payload.Should().NotBeNull();
+        payload!.Email.Should().Be("updated@example.com");
+    }
+
+    [Fact]
+    public async Task DeletePatient_ReturnsNoContent_WhenSuccessful()
+    {
+        var fake = new FakePatientService();
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = app.GetTestClient();
+
+        var response = await client.DeleteAsync("/api/Patient/patient-1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    private static async Task<WebApplication> BuildAppAsync(FakePatientService fakePatientService)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        builder.Services.AddControllers()
+            .AddApplicationPart(typeof(PatientController).Assembly);
+
+        builder.Services.AddSingleton<IPatientService>(fakePatientService);
+
+        var app = builder.Build();
+        app.MapControllers();
+
+        await app.StartAsync();
+        return app;
+    }
+
+    private sealed class FakePatientService : IPatientService
+    {
+        public IEnumerable<PatientResponseDTO> Patients { get; set; } = Array.Empty<PatientResponseDTO>();
+        public PatientResponseDTO? CreatedPatient { get; set; }
+        public PatientResponseDTO? UpdatedPatient { get; set; }
+
+        public Task<PatientResponseDTO?> GetPatientByIdAsync(string id)
+            => Task.FromResult(id == "missing" ? null : new PatientResponseDTO { Id = id, Email = "patient@example.com", FirstName = "Pat", LastName = "Ient" });
+
+        public Task<IEnumerable<PatientResponseDTO>> GetAllPatientsAsync(int pageNumber = 1, int pageSize = 10)
+            => Task.FromResult(Patients);
+
+        public Task<PatientResponseDTO> CreatePatientAsync(PatientCreateDTO patientDto)
+            => Task.FromResult(CreatedPatient ?? new PatientResponseDTO { Id = "patient-1", Email = patientDto.Email, FirstName = patientDto.FirstName, LastName = patientDto.LastName });
+
+        public Task<PatientResponseDTO?> UpdatePatientAsync(string id, PatientUpdateDTO patientDto)
+            => Task.FromResult<PatientResponseDTO?>(UpdatedPatient ?? new PatientResponseDTO { Id = id, Email = patientDto.Email ?? "updated@example.com", FirstName = patientDto.FirstName ?? "Updated", LastName = patientDto.LastName ?? "User" });
+
+        public Task DeletePatientAsync(string id) => Task.CompletedTask;
+        public Task HardDeletePatientAsync(string id) => Task.CompletedTask;
+    }
+}

--- a/BreastCancer.Tests/Unit/PatientServiceTests.cs
+++ b/BreastCancer.Tests/Unit/PatientServiceTests.cs
@@ -1,0 +1,300 @@
+using AutoMapper;
+using BreastCancer.DTO.request;
+using BreastCancer.DTO.response;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
+using BreastCancer.Service.Implementation;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace BreastCancer.Tests.Unit;
+
+public class PatientServiceTests
+{
+    [Fact]
+    public async Task GetPatientByIdAsync_WhenPatientExists_ReturnsMappedPatient()
+    {
+        var sut = CreateSut();
+        var patient = CreatePatientEntity("patient-1");
+
+        sut.PatientRepository.Setup(x => x.GetByIdAsync("patient-1")).ReturnsAsync(patient);
+
+        var result = await sut.Service.GetPatientByIdAsync("patient-1");
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be("patient-1");
+        result.Email.Should().Be("patient@example.com");
+        result.MedicalHistory.Should().Be("History");
+    }
+
+    [Fact]
+    public async Task GetPatientByIdAsync_WhenPatientMissing_ReturnsNull()
+    {
+        var sut = CreateSut();
+
+        sut.PatientRepository.Setup(x => x.GetByIdAsync("missing")).ReturnsAsync((Patient?)null);
+
+        var result = await sut.Service.GetPatientByIdAsync("missing");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAllPatientsAsync_WhenPageIsValid_ReturnsMappedPatients()
+    {
+        var sut = CreateSut();
+        var patients = new[]
+        {
+            CreatePatientEntity("patient-1"),
+            CreatePatientEntity("patient-2", "second@example.com")
+        };
+
+        sut.PatientRepository.Setup(x => x.GetPagedAsync(1, 10)).ReturnsAsync(patients);
+
+        var result = await sut.Service.GetAllPatientsAsync(1, 10);
+
+        result.Should().HaveCount(2);
+        result.Select(x => x.Id).Should().ContainInOrder("patient-1", "patient-2");
+    }
+
+    [Fact]
+    public async Task GetAllPatientsAsync_WhenPageNumberInvalid_ThrowsArgumentException()
+    {
+        var sut = CreateSut();
+
+        var act = async () => await sut.Service.GetAllPatientsAsync(0, 10);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("Page number must be greater than 0.*");
+    }
+
+    [Fact]
+    public async Task CreatePatientAsync_WhenEmailAlreadyExists_ThrowsInvalidOperationException()
+    {
+        var sut = CreateSut();
+        sut.UserManager.Setup(x => x.FindByEmailAsync("patient@example.com"))
+            .ReturnsAsync(new ApplicationUser { Id = "existing", Email = "patient@example.com" });
+
+        var act = async () => await sut.Service.CreatePatientAsync(new PatientCreateDTO
+        {
+            FirstName = "Pat",
+            LastName = "Ient",
+            Email = "patient@example.com"
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("A user with email 'patient@example.com' already exists.");
+    }
+
+    [Fact]
+    public async Task CreatePatientAsync_WhenDoctorIsMissing_ThrowsInvalidOperationException()
+    {
+        var sut = CreateSut();
+        sut.UserManager.Setup(x => x.FindByEmailAsync("patient@example.com")).ReturnsAsync((ApplicationUser?)null);
+        sut.DoctorRepository.Setup(x => x.GetByIdAsync("doctor-1")).ReturnsAsync((Doctor?)null);
+
+        var act = async () => await sut.Service.CreatePatientAsync(new PatientCreateDTO
+        {
+            FirstName = "Pat",
+            LastName = "Ient",
+            Email = "patient@example.com",
+            DoctorId = "doctor-1"
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Doctor with ID 'doctor-1' not found.");
+    }
+
+    [Fact]
+    public async Task CreatePatientAsync_WhenValid_CreatesAndReturnsPatient()
+    {
+        var sut = CreateSut();
+        sut.UserManager.Setup(x => x.FindByEmailAsync("patient@example.com")).ReturnsAsync((ApplicationUser?)null);
+        sut.UserManager
+            .Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+            .Callback<ApplicationUser, string>((user, _) => user.Id = "patient-1")
+            .ReturnsAsync(IdentityResult.Success);
+        sut.UserManager.Setup(x => x.AddToRoleAsync(It.IsAny<ApplicationUser>(), "Patient"))
+            .ReturnsAsync(IdentityResult.Success);
+
+        var createdPatient = CreatePatientEntity("patient-1");
+        sut.PatientRepository.Setup(x => x.GetByIdAsync("patient-1")).ReturnsAsync(createdPatient);
+        sut.PatientRepository.Setup(x => x.SaveChangesAsync()).Returns(Task.CompletedTask);
+
+        var result = await sut.Service.CreatePatientAsync(new PatientCreateDTO
+        {
+            FirstName = "Pat",
+            LastName = "Ient",
+            Email = "patient@example.com",
+            PhoneNumber = "1234567890",
+            Address = "Addr",
+            MedicalHistory = "History"
+        });
+
+        result.Should().NotBeNull();
+        result.Id.Should().Be("patient-1");
+        result.Email.Should().Be("patient@example.com");
+        result.MedicalHistory.Should().Be("History");
+
+        sut.PatientRepository.Verify(x => x.Add(It.IsAny<Patient>()), Times.Once);
+        sut.PatientRepository.Verify(x => x.SaveChangesAsync(), Times.Once);
+        sut.UserManager.Verify(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()), Times.Once);
+        sut.UserManager.Verify(x => x.AddToRoleAsync(It.IsAny<ApplicationUser>(), "Patient"), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdatePatientAsync_WhenPatientMissing_ReturnsNull()
+    {
+        var sut = CreateSut();
+        sut.PatientRepository.Setup(x => x.GetByIdAsync("missing")).ReturnsAsync((Patient?)null);
+
+        var result = await sut.Service.UpdatePatientAsync("missing", new PatientUpdateDTO());
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdatePatientAsync_WhenValid_UpdatesAndReturnsMappedPatient()
+    {
+        var sut = CreateSut();
+        var patient = CreatePatientEntity("patient-1");
+        sut.PatientRepository.SetupSequence(x => x.GetByIdAsync("patient-1"))
+            .ReturnsAsync(patient)
+            .ReturnsAsync(CreatePatientEntity("patient-1", "updated@example.com", "Updated", "User", "Updated history"));
+        sut.UserManager.Setup(x => x.FindByEmailAsync("updated@example.com")).ReturnsAsync((ApplicationUser?)null);
+        sut.UserManager.Setup(x => x.UpdateAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(IdentityResult.Success);
+        sut.PatientRepository.Setup(x => x.Update(It.IsAny<Patient>()));
+        sut.PatientRepository.Setup(x => x.SaveChangesAsync()).Returns(Task.CompletedTask);
+
+        var result = await sut.Service.UpdatePatientAsync("patient-1", new PatientUpdateDTO
+        {
+            FirstName = "Updated",
+            Email = "updated@example.com",
+            MedicalHistory = "Updated history",
+            IsActive = false
+        });
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be("patient-1");
+        result.Email.Should().Be("updated@example.com");
+        result.MedicalHistory.Should().Be("Updated history");
+        result.FirstName.Should().Be("Updated");
+    }
+
+    [Fact]
+    public async Task DeletePatientAsync_WhenValid_DeactivatesUser()
+    {
+        var sut = CreateSut();
+        var patient = CreatePatientEntity("patient-1");
+        sut.PatientRepository.Setup(x => x.GetByIdAsync("patient-1")).ReturnsAsync(patient);
+        sut.UserManager.Setup(x => x.UpdateAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(IdentityResult.Success);
+        sut.PatientRepository.Setup(x => x.SaveChangesAsync()).Returns(Task.CompletedTask);
+
+        await sut.Service.DeletePatientAsync("patient-1");
+
+        sut.UserManager.Verify(x => x.UpdateAsync(It.Is<ApplicationUser>(u => u.IsActive == false)), Times.Once);
+        sut.PatientRepository.Verify(x => x.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task HardDeletePatientAsync_WhenValid_DeletesUser()
+    {
+        var sut = CreateSut();
+        var patient = CreatePatientEntity("patient-1");
+        sut.PatientRepository.Setup(x => x.GetByIdAsync("patient-1")).ReturnsAsync(patient);
+        sut.UserManager.Setup(x => x.DeleteAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(IdentityResult.Success);
+
+        await sut.Service.HardDeletePatientAsync("patient-1");
+
+        sut.UserManager.Verify(x => x.DeleteAsync(It.Is<ApplicationUser>(u => u.Id == "patient-1")), Times.Once);
+    }
+
+    private static Patient CreatePatientEntity(string id, string email = "patient@example.com", string firstName = "Pat", string lastName = "Ient", string? history = "History")
+    {
+        var user = new ApplicationUser
+        {
+            Id = id,
+            Email = email,
+            UserName = email,
+            FirstName = firstName,
+            LastName = lastName,
+            PhoneNumber = "1234567890",
+            Address = "Addr",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow.AddDays(-1),
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        return new Patient
+        {
+            UserId = id,
+            MedicalHistory = history,
+            DoctorId = null,
+            User = user
+        };
+    }
+
+    private static SutContext CreateSut()
+    {
+        var userStore = new Mock<IUserStore<ApplicationUser>>();
+        var userManager = new Mock<UserManager<ApplicationUser>>(
+            userStore.Object,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!);
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var patientRepository = new Mock<IPatientRepository>();
+        var doctorRepository = new Mock<IDoctorRepository>();
+        var logger = new Mock<ILogger<PatientService>>();
+        var mapper = new Mock<IMapper>();
+        mapper.Setup(x => x.Map<PatientResponseDTO>(It.IsAny<Patient>()))
+            .Returns((Patient source) => MapPatient(source));
+        mapper.Setup(x => x.Map<IEnumerable<PatientResponseDTO>>(It.IsAny<IEnumerable<Patient>>()))
+            .Returns((IEnumerable<Patient> sources) => sources.Select(MapPatient).ToArray());
+
+        unitOfWork.SetupGet(x => x.PatientsRepository).Returns(patientRepository.Object);
+        unitOfWork.SetupGet(x => x.DoctorsRepository).Returns(doctorRepository.Object);
+
+        var service = new PatientService(unitOfWork.Object, userManager.Object, logger.Object, mapper.Object);
+
+        return new SutContext(service, userManager, unitOfWork, patientRepository, doctorRepository);
+    }
+
+    private sealed record SutContext(
+        PatientService Service,
+        Mock<UserManager<ApplicationUser>> UserManager,
+        Mock<IUnitOfWork> UnitOfWork,
+        Mock<IPatientRepository> PatientRepository,
+        Mock<IDoctorRepository> DoctorRepository);
+
+    private static PatientResponseDTO MapPatient(Patient source) => new()
+    {
+        Id = source.UserId,
+        FirstName = source.User?.FirstName ?? string.Empty,
+        LastName = source.User?.LastName ?? string.Empty,
+        FullName = source.User?.FullName ?? string.Empty,
+        Email = source.User?.Email ?? string.Empty,
+        PhoneNumber = source.User?.PhoneNumber,
+        Address = source.User?.Address,
+        ImageUrl = source.User?.ImageUrl,
+        DateOfBirth = source.User?.DateOfBirth,
+        Age = source.User?.Age,
+        Gender = source.User?.Gender,
+        IsActive = source.User?.IsActive ?? false,
+        MedicalHistory = source.MedicalHistory,
+        DoctorId = source.DoctorId,
+        TreatmentPlanId = source.TreatmentPlan?.Id,
+        DoctorName = source.Doctor?.User?.FullName,
+        CreatedAt = source.User?.CreatedAt ?? default,
+        UpdatedAt = source.User?.UpdatedAt ?? default
+    };
+}


### PR DESCRIPTION
**Summary**
Added unit and integration test coverage for the patient flow to strengthen validation across core CRUD operations and improve overall project coverage.

**What was added**
- Unit tests for PatientService covering:
  - get patient by ID
  - get all patients with pagination
  - create patient success and validation failures
  - update patient success and not found handling
  - soft delete and hard delete behavior
- Integration tests for PatientController covering:
  - get all patients
  - get patient by ID
  - create patient
  - update patient
  - delete patient

**Why**
- Expands test coverage beyond account flows
- Adds protection around patient business logic and controller behavior
- Helps keep the whole-project coverage gate moving upward safely

**Validation**
- `dotnet test BreastCancer.Tests\BreastCancer.Tests.csproj` passes
- New patient tests pass successfully with the rest of the suite
