### PR TITLE
Fix TreatmentPlanHistory for EF Null Handling

### DIFF
--- a/Models/TreatmentPlanHistory.cs
+++ b/Models/TreatmentPlanHistory.cs
@@ -12,7 +12,7 @@ namespace BreastCancer.Models
 
         [Required]
         public int TreatmentPlanId { get; set; }
-        public virtual TreatmentPlan TreatmentPlan { get; set; }
+        public virtual TreatmentPlan TreatmentPlan { get; set; } = null!;
 
         [Required]
         public TreatmentPlanStatus Status { get; set; }


### PR DESCRIPTION
Why this works: = null!; tells the compiler “this will be populated later” (by EF materialization), while keeping the relationship non-nullable in your model.