### PR TITLE
Add tests for Caregiver Service

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -31,7 +31,7 @@ jobs:
           /p:CollectCoverage=true
           /p:CoverletOutput=./TestResults/coverage/
           /p:CoverletOutputFormat=cobertura
-          /p:Threshold=9
+          /p:Threshold=11
           /p:ThresholdType=line
           /p:ThresholdStat=total
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,7 +13,7 @@
         "/p:CollectCoverage=true",
         "/p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage/",
         "/p:CoverletOutputFormat=cobertura",
-        "/p:Threshold=9",
+        "/p:Threshold=11",
         "/p:ThresholdType=line",
         "/p:ThresholdStat=total"
       ],

--- a/BreastCancer.Tests/Integration/CaregiverControllerIntegrationTests.cs
+++ b/BreastCancer.Tests/Integration/CaregiverControllerIntegrationTests.cs
@@ -1,0 +1,260 @@
+using System.Net;
+using System.Net.Http.Json;
+using BreastCancer.Controllers;
+using BreastCancer.DTO.request;
+using BreastCancer.DTO.response;
+using BreastCancer.Enum;
+using BreastCancer.Service.Interface;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BreastCancer.Tests.Integration;
+
+public class CaregiverControllerIntegrationTests
+{
+    [Fact]
+    public async Task GetAllCaregivers_ReturnsOk_WhenServiceReturnsCaregivers()
+    {
+        var fake = new FakeCaregiverService
+        {
+            Caregivers = new[]
+            {
+                new CaregiverResponse { Id = "caregiver-1", Name = "Care Giver", Email = "caregiver1@example.com", PatientId = "patient-1" },
+                new CaregiverResponse { Id = "caregiver-2", Name = "Care Giver 2", Email = "caregiver2@example.com", PatientId = "patient-2" }
+            }
+        };
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = app.GetTestClient();
+
+        var response = await client.GetAsync("/api/Caregiver");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<CaregiverResponse[]>();
+        payload.Should().NotBeNull();
+        payload!.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetAllCaregivers_ReturnsNotFound_WhenServiceReturnsEmpty()
+    {
+        var fake = new FakeCaregiverService { Caregivers = Array.Empty<CaregiverResponse>() };
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = app.GetTestClient();
+
+        var response = await client.GetAsync("/api/Caregiver");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetCaregiverById_ReturnsNotFound_WhenMissing()
+    {
+        var fake = new FakeCaregiverService();
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = app.GetTestClient();
+
+        var response = await client.GetAsync("/api/Caregiver/missing");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetCaregiverByPatientId_ReturnsOk_WhenFound()
+    {
+        var fake = new FakeCaregiverService
+        {
+            ByPatient = new[]
+            {
+                new CaregiverResponse { Id = "caregiver-1", Name = "Care Giver", Email = "caregiver@example.com", PatientId = "patient-1" }
+            }
+        };
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = app.GetTestClient();
+
+        var response = await client.GetAsync("/api/Caregiver/patient/patient-1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<CaregiverResponse[]>();
+        payload.Should().NotBeNull();
+        payload!.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task GetCaregiverByPatientId_ReturnsNotFound_WhenNone()
+    {
+        var fake = new FakeCaregiverService { ByPatient = Array.Empty<CaregiverResponse>() };
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = app.GetTestClient();
+
+        var response = await client.GetAsync("/api/Caregiver/patient/patient-1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CreateCaregiver_ReturnsCreated_WhenValid()
+    {
+        var fake = new FakeCaregiverService();
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync("/api/Caregiver", new CaregiverCreateDTO
+        {
+            FirstName = "Care",
+            LastName = "Giver",
+            Email = "caregiver@example.com",
+            PatientId = "patient-1",
+            RelationshipType = RelationshipType.FRIEND
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task UpdateCaregiver_ReturnsNoContent_WhenValid()
+    {
+        var fake = new FakeCaregiverService();
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = app.GetTestClient();
+
+        var response = await client.PutAsJsonAsync("/api/Caregiver/caregiver-1", new CaregiverUpdateDTO
+        {
+            FirstName = "Updated",
+            Address = "New Address"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task DeleteCaregiver_ReturnsNoContent_WhenValid()
+    {
+        var fake = new FakeCaregiverService();
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = app.GetTestClient();
+
+        var response = await client.DeleteAsync("/api/Caregiver/caregiver-1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task HardDeleteCaregiver_ReturnsNoContent_WhenValid()
+    {
+        var fake = new FakeCaregiverService();
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = app.GetTestClient();
+
+        var response = await client.DeleteAsync("/api/Caregiver/hard/caregiver-1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    private static async Task<WebApplication> BuildAppAsync(FakeCaregiverService fakeCaregiverService)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        builder.Services
+            .AddAuthentication(TestAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, _ => { });
+        builder.Services.AddAuthorization();
+
+        builder.Services.AddControllers()
+            .AddApplicationPart(typeof(CaregiverController).Assembly);
+
+        builder.Services.AddSingleton<ICaregiverService>(fakeCaregiverService);
+
+        var app = builder.Build();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.MapControllers();
+
+        await app.StartAsync();
+        return app;
+    }
+
+    private sealed class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public const string SchemeName = "Test";
+
+        public TestAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var claims = new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "test-user"),
+                new Claim(ClaimTypes.Name, "integration-test-user"),
+                new Claim(ClaimTypes.Role, "Admin"),
+                new Claim(ClaimTypes.Role, "Doctor")
+            };
+
+            var identity = new ClaimsIdentity(claims, SchemeName);
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, SchemeName);
+
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+
+    private sealed class FakeCaregiverService : ICaregiverService
+    {
+        public IEnumerable<CaregiverResponse> Caregivers { get; set; } = Array.Empty<CaregiverResponse>();
+        public IEnumerable<CaregiverResponse> ByPatient { get; set; } = Array.Empty<CaregiverResponse>();
+
+        public Task<IEnumerable<CaregiverResponse>> GetAllCaregivers() => Task.FromResult(Caregivers);
+
+        public Task<CaregiverResponse> GetCaregiverById(string id)
+        {
+            if (id == "missing")
+            {
+                return Task.FromResult<CaregiverResponse>(null!);
+            }
+
+            return Task.FromResult(new CaregiverResponse
+            {
+                Id = id,
+                Name = "Care Giver",
+                Email = "caregiver@example.com",
+                PatientId = "patient-1"
+            });
+        }
+
+        public Task<IEnumerable<CaregiverResponse>> GetCaregiverByPatientId(string patientId)
+            => Task.FromResult(ByPatient);
+
+        public Task CreateCaregiver(CaregiverCreateDTO caregiverDto) => Task.CompletedTask;
+
+        public Task UpdateCaregiver(string id, CaregiverUpdateDTO updateDto) => Task.CompletedTask;
+
+        public Task DeleteCaregiver(string id) => Task.CompletedTask;
+
+        public Task HardDeleteCaregiverById(string id) => Task.CompletedTask;
+    }
+}

--- a/BreastCancer.Tests/Integration/CaregiverControllerIntegrationTests.cs
+++ b/BreastCancer.Tests/Integration/CaregiverControllerIntegrationTests.cs
@@ -234,7 +234,7 @@ public class CaregiverControllerIntegrationTests
         {
             if (id == "missing")
             {
-                return Task.FromResult<CaregiverResponse>(null!);
+                throw new Exception("Caregiver not found.");
             }
 
             return Task.FromResult(new CaregiverResponse

--- a/BreastCancer.Tests/Unit/CaregiverServiceTests.cs
+++ b/BreastCancer.Tests/Unit/CaregiverServiceTests.cs
@@ -1,0 +1,306 @@
+using AutoMapper;
+using BreastCancer.DTO.request;
+using BreastCancer.DTO.response;
+using BreastCancer.Enum;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
+using BreastCancer.Service.Implementation;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Moq;
+using Xunit;
+
+namespace BreastCancer.Tests.Unit;
+
+public class CaregiverServiceTests
+{
+    [Fact]
+    public async Task GetAllCaregivers_WhenRepositoryReturnsActiveCaregivers_ReturnsMappedCaregivers()
+    {
+        var sut = CreateSut();
+        var caregivers = new[]
+        {
+            CreateCaregiverEntity("caregiver-1"),
+            CreateCaregiverEntity("caregiver-2", "second@example.com", "patient-2")
+        };
+
+        sut.CaregiverRepository
+            .Setup(x => x.FilterAsync(It.IsAny<System.Linq.Expressions.Expression<Func<Caregiver, bool>>>(), null, null, null))
+            .ReturnsAsync(caregivers);
+
+        var result = await sut.Service.GetAllCaregivers();
+
+        result.Should().HaveCount(2);
+        result.Select(x => x.Id).Should().ContainInOrder("caregiver-1", "caregiver-2");
+    }
+
+    [Fact]
+    public async Task GetAllCaregivers_WhenRepositoryReturnsNone_ReturnsEmpty()
+    {
+        var sut = CreateSut();
+
+        sut.CaregiverRepository
+            .Setup(x => x.FilterAsync(It.IsAny<System.Linq.Expressions.Expression<Func<Caregiver, bool>>>(), null, null, null))
+            .ReturnsAsync(Array.Empty<Caregiver>());
+
+        var result = await sut.Service.GetAllCaregivers();
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetCaregiverById_WhenCaregiverExists_ReturnsMappedCaregiver()
+    {
+        var sut = CreateSut();
+        var caregiver = CreateCaregiverEntity("caregiver-1");
+
+        sut.CaregiverRepository.Setup(x => x.GetByIdAsync("caregiver-1")).ReturnsAsync(caregiver);
+
+        var result = await sut.Service.GetCaregiverById("caregiver-1");
+
+        result.Should().NotBeNull();
+        result.Id.Should().Be("caregiver-1");
+        result.Email.Should().Be("caregiver@example.com");
+        result.PatientId.Should().Be("patient-1");
+    }
+
+    [Fact]
+    public async Task GetCaregiverById_WhenMissing_ThrowsException()
+    {
+        var sut = CreateSut();
+
+        sut.CaregiverRepository.Setup(x => x.GetByIdAsync("missing")).ReturnsAsync((Caregiver?)null);
+
+        var act = async () => await sut.Service.GetCaregiverById("missing");
+
+        await act.Should().ThrowAsync<Exception>()
+            .WithMessage("Caregiver not found.");
+    }
+
+    [Fact]
+    public async Task GetCaregiverByPatientId_WhenMatchesFound_ReturnsMappedCaregivers()
+    {
+        var sut = CreateSut();
+        var caregivers = new[]
+        {
+            CreateCaregiverEntity("caregiver-1", patientId: "patient-1"),
+            CreateCaregiverEntity("caregiver-2", "second@example.com", "patient-1")
+        };
+
+        sut.CaregiverRepository
+            .Setup(x => x.FilterAsync(It.IsAny<System.Linq.Expressions.Expression<Func<Caregiver, bool>>>(), null, null, null))
+            .ReturnsAsync(caregivers);
+
+        var result = await sut.Service.GetCaregiverByPatientId("patient-1");
+
+        result.Should().HaveCount(2);
+        result.All(x => x.PatientId == "patient-1").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateCaregiver_WhenEmailExists_ThrowsException()
+    {
+        var sut = CreateSut();
+
+        sut.UserManager.Setup(x => x.FindByEmailAsync("caregiver@example.com"))
+            .ReturnsAsync(new ApplicationUser { Id = "existing", Email = "caregiver@example.com" });
+
+        var act = async () => await sut.Service.CreateCaregiver(new CaregiverCreateDTO
+        {
+            FirstName = "Care",
+            LastName = "Giver",
+            Email = "caregiver@example.com",
+            PatientId = "patient-1"
+        });
+
+        await act.Should().ThrowAsync<Exception>()
+            .WithMessage("User with the same email already exists.");
+    }
+
+    [Fact]
+    public async Task CreateCaregiver_WhenValid_CreatesCaregiverAndPersists()
+    {
+        var sut = CreateSut();
+
+        sut.UserManager.Setup(x => x.FindByEmailAsync("caregiver@example.com"))
+            .ReturnsAsync((ApplicationUser?)null);
+        sut.UserManager
+            .Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+            .Callback<ApplicationUser, string>((user, _) => user.Id = "caregiver-1")
+            .ReturnsAsync(IdentityResult.Success);
+        sut.UserManager
+            .Setup(x => x.AddToRoleAsync(It.IsAny<ApplicationUser>(), "Caregiver"))
+            .ReturnsAsync(IdentityResult.Success);
+        sut.CaregiverRepository.Setup(x => x.AddAsync(It.IsAny<Caregiver>())).Returns(Task.CompletedTask);
+        sut.UnitOfWork.Setup(x => x.SaveAsync()).ReturnsAsync(1);
+
+        await sut.Service.CreateCaregiver(new CaregiverCreateDTO
+        {
+            FirstName = "Care",
+            LastName = "Giver",
+            Email = "caregiver@example.com",
+            PatientId = "patient-1",
+            RelationshipType = RelationshipType.FRIEND
+        });
+
+        sut.CaregiverRepository.Verify(
+            x => x.AddAsync(It.Is<Caregiver>(c => c.UserId == "caregiver-1" && c.PatientId == "patient-1")),
+            Times.Once);
+        sut.UnitOfWork.Verify(x => x.SaveAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateCaregiver_WhenUserMissing_ThrowsException()
+    {
+        var sut = CreateSut();
+
+        sut.UserManager.Setup(x => x.FindByIdAsync("missing")).ReturnsAsync((ApplicationUser?)null);
+
+        var act = async () => await sut.Service.UpdateCaregiver("missing", new CaregiverUpdateDTO { FirstName = "Updated" });
+
+        await act.Should().ThrowAsync<Exception>()
+            .WithMessage("User not found.");
+    }
+
+    [Fact]
+    public async Task UpdateCaregiver_WhenValid_UpdatesUser()
+    {
+        var sut = CreateSut();
+        var user = new ApplicationUser
+        {
+            Id = "caregiver-1",
+            FirstName = "Care",
+            LastName = "Giver",
+            Address = "Old address"
+        };
+
+        sut.UserManager.Setup(x => x.FindByIdAsync("caregiver-1")).ReturnsAsync(user);
+        sut.UserManager.Setup(x => x.UpdateAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(IdentityResult.Success);
+
+        await sut.Service.UpdateCaregiver("caregiver-1", new CaregiverUpdateDTO
+        {
+            FirstName = "Updated",
+            Address = "New address"
+        });
+
+        sut.UserManager.Verify(
+            x => x.UpdateAsync(It.Is<ApplicationUser>(u => u.FirstName == "Updated" && u.Address == "New address")),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteCaregiver_WhenValid_SetsUserInactiveAndSaves()
+    {
+        var sut = CreateSut();
+        var caregiver = CreateCaregiverEntity("caregiver-1");
+
+        sut.CaregiverRepository.Setup(x => x.GetByIdAsync("caregiver-1")).ReturnsAsync(caregiver);
+        sut.UnitOfWork.Setup(x => x.SaveAsync()).ReturnsAsync(1);
+
+        await sut.Service.DeleteCaregiver("caregiver-1");
+
+        sut.CaregiverRepository.Verify(x => x.Update(It.Is<Caregiver>(c => c.User.IsActive == false)), Times.Once);
+        sut.UnitOfWork.Verify(x => x.SaveAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task HardDeleteCaregiverById_WhenValid_DeletesAndSaves()
+    {
+        var sut = CreateSut();
+        var caregiver = CreateCaregiverEntity("caregiver-1");
+
+        sut.CaregiverRepository.Setup(x => x.GetByIdAsync("caregiver-1")).ReturnsAsync(caregiver);
+        sut.UnitOfWork.Setup(x => x.SaveAsync()).ReturnsAsync(1);
+
+        await sut.Service.HardDeleteCaregiverById("caregiver-1");
+
+        sut.CaregiverRepository.Verify(x => x.Delete(It.Is<Caregiver>(c => c.UserId == "caregiver-1")), Times.Once);
+        sut.UnitOfWork.Verify(x => x.SaveAsync(), Times.Once);
+    }
+
+    private static Caregiver CreateCaregiverEntity(
+        string id,
+        string email = "caregiver@example.com",
+        string patientId = "patient-1")
+    {
+        var user = new ApplicationUser
+        {
+            Id = id,
+            Email = email,
+            UserName = email,
+            FirstName = "Care",
+            LastName = "Giver",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow.AddDays(-1),
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        return new Caregiver
+        {
+            UserId = id,
+            User = user,
+            PatientId = patientId,
+            RelationshipType = RelationshipType.FRIEND
+        };
+    }
+
+    private static SutContext CreateSut()
+    {
+        var userStore = new Mock<IUserStore<ApplicationUser>>();
+        var userManager = new Mock<UserManager<ApplicationUser>>(
+            userStore.Object,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!);
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var caregiverRepository = new Mock<ICaregiverRepository>();
+        var mapper = new Mock<IMapper>();
+
+        mapper.Setup(x => x.Map<CaregiverResponse>(It.IsAny<Caregiver>()))
+            .Returns((Caregiver source) => MapCaregiver(source));
+        mapper.Setup(x => x.Map<IEnumerable<CaregiverResponse>>(It.IsAny<IEnumerable<Caregiver>>()))
+            .Returns((IEnumerable<Caregiver> sources) => sources.Select(MapCaregiver).ToArray());
+        mapper.Setup(x => x.Map<Caregiver>(It.IsAny<CaregiverCreateDTO>()))
+            .Returns((CaregiverCreateDTO source) => new Caregiver
+            {
+                PatientId = source.PatientId,
+                RelationshipType = source.RelationshipType,
+                User = new ApplicationUser()
+            });
+        mapper.Setup(x => x.Map(It.IsAny<CaregiverUpdateDTO>(), It.IsAny<ApplicationUser>()))
+            .Callback<CaregiverUpdateDTO, ApplicationUser>((source, destination) =>
+            {
+                if (!string.IsNullOrEmpty(source.FirstName)) destination.FirstName = source.FirstName;
+                if (!string.IsNullOrEmpty(source.LastName)) destination.LastName = source.LastName;
+                if (!string.IsNullOrEmpty(source.Address)) destination.Address = source.Address;
+                if (!string.IsNullOrEmpty(source.ImageUrl)) destination.ImageUrl = source.ImageUrl;
+            });
+
+        unitOfWork.SetupGet(x => x.CaregiversRepository).Returns(caregiverRepository.Object);
+
+        var service = new CaregiverService(unitOfWork.Object, mapper.Object, userManager.Object);
+
+        return new SutContext(service, unitOfWork, caregiverRepository, userManager);
+    }
+
+    private sealed record SutContext(
+        CaregiverService Service,
+        Mock<IUnitOfWork> UnitOfWork,
+        Mock<ICaregiverRepository> CaregiverRepository,
+        Mock<UserManager<ApplicationUser>> UserManager);
+
+    private static CaregiverResponse MapCaregiver(Caregiver source) => new()
+    {
+        Id = source.UserId,
+        Name = source.User?.FullName ?? string.Empty,
+        Email = source.User?.Email ?? string.Empty,
+        PatientId = source.PatientId,
+        RelationshipType = source.RelationshipType
+    };
+}

--- a/Controllers/CaregiverController.cs
+++ b/Controllers/CaregiverController.cs
@@ -40,12 +40,15 @@ namespace BreastCancer.Controllers
         [SwaggerResponse(StatusCodes.Status404NotFound, "Caregiver not found")]
         public async Task<IActionResult> GetCaregiverById(string id)
         {
-            var caregiver = await _caregiverService.GetCaregiverById(id);
-            if (caregiver == null)
+            try
             {
-                return NotFound();
+                var caregiver = await _caregiverService.GetCaregiverById(id);
+                return Ok(caregiver);
             }
-            return Ok(caregiver);
+            catch (Exception ex) when (ex.Message == "Caregiver not found.")
+            {
+                return NotFound(new { message = ex.Message });
+            }
         }
 
         [HttpGet("patient/{patientId}")]
@@ -70,7 +73,7 @@ namespace BreastCancer.Controllers
         [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized access")]
         public async Task<IActionResult> CreateCaregiver([FromBody] CaregiverCreateDTO caregiverDto)
         {
-             await _caregiverService.CreateCaregiver(caregiverDto);
+            await _caregiverService.CreateCaregiver(caregiverDto);
             return CreatedAtAction(nameof(GetAllCaregivers), null);
         }
 


### PR DESCRIPTION
This pull request introduces comprehensive unit and integration tests for the caregiver functionality and increases the code coverage threshold for both local and CI test runs. The new tests ensure that the caregiver service and controller endpoints are robust and behave as expected under various scenarios.

**Testing improvements:**

* Added a full suite of integration tests for the `CaregiverController`, covering all major endpoints and scenarios, including successful and failure cases. (`BreastCancer.Tests/Integration/CaregiverControllerIntegrationTests.cs`)
* Added extensive unit tests for the `CaregiverService`, verifying correct behavior for all core service methods, including edge cases and exception handling. (`BreastCancer.Tests/Unit/CaregiverServiceTests.cs`)

**Code quality enforcement:**

* Increased the code coverage threshold from 9% to 11% in both the CI workflow and VSCode tasks to reflect the improved test coverage and enforce higher quality standards. (`.github/workflows/dotnet-tests.yml`, `.vscode/tasks.json`) [[1]](diffhunk://#diff-59d9cb04d09818e21daa7f304df35a231f3abced427cf07e0f96e50a17d72acbL34-R34) [[2]](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aL16-R16)