### PR TITLE
CI/CD: Add Scoped Coverage Gate and Keep Full Coverage Artifact

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -23,15 +23,25 @@ jobs:
       - name: Restore
         run: dotnet restore BreastCancer.sln
 
-      - name: Run tests with coverage threshold (Whole Project)
+      - name: Run tests with full coverage report (no gate)
         run: >-
           dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj
           --configuration Release
           --no-restore
           /p:CollectCoverage=true
-          /p:CoverletOutput=./TestResults/coverage/
+          /p:CoverletOutput=./TestResults/coverage-full/
           /p:CoverletOutputFormat=cobertura
-          /p:Threshold=11
+
+      - name: Run tests with scoped coverage gate (business logic)
+        run: >-
+          dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj
+          --configuration Release
+          --no-restore
+          /p:CollectCoverage=true
+          /p:CoverletOutput=./TestResults/coverage-scoped/
+          /p:CoverletOutputFormat=cobertura
+          /p:ExcludeByFile="/Migrations/%2c**/*.Designer.cs%2c**/Program.cs%2c**/Context/%2c/Templates/**"
+          /p:Threshold=30
           /p:ThresholdType=line
           /p:ThresholdStat=total
 
@@ -39,6 +49,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-cobertura
-          path: BreastCancer.Tests/TestResults/coverage/coverage.cobertura.xml
+          name: coverage-cobertura-full
+          path: BreastCancer.Tests/TestResults/coverage-full/coverage.cobertura.xml
+          if-no-files-found: warn
+
+      - name: Upload scoped coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-cobertura-scoped
+          path: BreastCancer.Tests/TestResults/coverage-scoped/coverage.cobertura.xml
           if-no-files-found: warn

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -40,7 +40,7 @@ jobs:
           /p:CollectCoverage=true
           /p:CoverletOutput=./TestResults/coverage-scoped/
           /p:CoverletOutputFormat=cobertura
-          /p:ExcludeByFile="/Migrations/%2c**/*.Designer.cs%2c**/Program.cs%2c**/Context/%2c/Templates/**"
+          /p:ExcludeByFile="**/Migrations/**%2c**/*.Designer.cs%2c**/Program.cs%2c**/Context/**%2c**/Templates/**"
           /p:Threshold=30
           /p:ThresholdType=line
           /p:ThresholdStat=total

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,9 +11,10 @@
         "--configuration",
         "Debug",
         "/p:CollectCoverage=true",
-        "/p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage/",
+        "/p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage-scoped/",
         "/p:CoverletOutputFormat=cobertura",
-        "/p:Threshold=11",
+        "/p:ExcludeByFile=\"/Migrations/%2c**/*.Designer.cs%2c**/Program.cs%2c**/Context/%2c/Templates/**\"",
+        "/p:Threshold=30",
         "/p:ThresholdType=line",
         "/p:ThresholdStat=total"
       ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,7 +13,7 @@
         "/p:CollectCoverage=true",
         "/p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage-scoped/",
         "/p:CoverletOutputFormat=cobertura",
-        "/p:ExcludeByFile=\"/Migrations/%2c**/*.Designer.cs%2c**/Program.cs%2c**/Context/%2c/Templates/**\"",
+        "/p:ExcludeByFile=\"**/Migrations/**%2c**/*.Designer.cs%2c**/Program.cs%2c**/Context/**%2c**/Templates/**\"",
         "/p:Threshold=30",
         "/p:ThresholdType=line",
         "/p:ThresholdStat=total"

--- a/README.md
+++ b/README.md
@@ -122,24 +122,28 @@ dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj --filter FullyQualified
 Coverage:
 
 ```bash
-# Generate coverage report (Cobertura)
-dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj --configuration Release /p:CollectCoverage=true /p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage/ /p:CoverletOutputFormat=cobertura
+# 1) Full coverage report (no threshold gate)
+dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj --configuration Release /p:CollectCoverage=true /p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage-full/ /p:CoverletOutputFormat=cobertura
 
-# Run with current threshold gate
-dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj --configuration Release /p:CollectCoverage=true /p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage/ /p:CoverletOutputFormat=cobertura /p:Threshold=2 /p:ThresholdType=line /p:ThresholdStat=total
+# 2) Scoped coverage gate (business logic only)
+dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj --configuration Release /p:CollectCoverage=true /p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage-scoped/ /p:CoverletOutputFormat=cobertura /p:ExcludeByFile="**/Migrations/**%2c**/*.Designer.cs%2c**/Program.cs%2c**/Context/**%2c**/Templates/**" /p:Threshold=30 /p:ThresholdType=line /p:ThresholdStat=total
+
+# Run both sequentially (Windows cmd)
+dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj --configuration Release /p:CollectCoverage=true /p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage-full/ /p:CoverletOutputFormat=cobertura && dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj --configuration Release /p:CollectCoverage=true /p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage-scoped/ /p:CoverletOutputFormat=cobertura /p:ExcludeByFile="**/Migrations/**%2c**/*.Designer.cs%2c**/Program.cs%2c**/Context/**%2c**/Templates/**" /p:Threshold=30 /p:ThresholdType=line /p:ThresholdStat=total
 ```
 
 Coverage file:
 
 ```text
-BreastCancer.Tests/TestResults/coverage/coverage.cobertura.xml
+BreastCancer.Tests/TestResults/coverage-full/coverage.cobertura.xml
+BreastCancer.Tests/TestResults/coverage-scoped/coverage.cobertura.xml
 ```
 
 CI (GitHub Actions):
 
 - Workflow: `.github/workflows/dotnet-tests.yml`
 - Trigger: pull requests, pushes to `main`/`master`
-- Action: run tests + coverage + threshold gate + upload coverage artifact
+- Action: run tests + full coverage report + scoped coverage threshold gate + upload both coverage artifacts
 
 ## Project Structure
 


### PR DESCRIPTION
This pull request updates the test coverage workflow and documentation to provide both a full coverage report and a stricter, business-logic-focused coverage gate. It introduces a clearer separation between overall and scoped coverage, raises the coverage threshold for the scoped gate, and updates relevant scripts, CI configuration, and documentation.

**Test coverage workflow improvements:**

* The GitHub Actions workflow `.github/workflows/dotnet-tests.yml` now runs two coverage checks: a full coverage report (no threshold) and a scoped coverage report (excluding boilerplate and infrastructure files) with a 30% line coverage threshold. Both coverage artifacts are uploaded separately.
* The VS Code task in `.vscode/tasks.json` is updated to match the new scoped coverage configuration, using the same exclusions and higher threshold.

**Documentation updates:**

* The `README.md` is revised to document both the full and scoped coverage commands, explain the new coverage file locations, and clarify the CI workflow steps.