### PR TITLE
refactor: make AI network dependency optional for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,22 @@ An AI-powered platform that predicts breast cancer recurrence and provides conti
 git clone https://github.com/mahmoud-40/BreastCancer.git
 cd BreastCancer
 
-# Start all services
-docker-compose up -d --build
+# Start the core services (Backend + Database)
+docker compose up -d --build
 
 # Verify containers are running
-docker-compose ps
+docker compose ps
 ```
 
 Wait ~30 seconds for SQL Server to initialize. Both containers should show `Up` status.
+
+### Running with AI Integration
+
+If you are running the separate AI chatbot stack locally and want the backend to connect to it, start the services using the AI override file:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.ai.yml up -d --build
+```
 
 ## Services
 
@@ -52,37 +60,40 @@ Use Swagger UI to test endpoints and authenticate.
 ## Docker Commands
 
 ```bash
-# Start services
-docker-compose up -d --build
+# Start core services standalone
+docker compose up -d --build
+
+# Start core services WITH AI integration
+docker compose -f docker-compose.yml -f docker-compose.ai.yml up -d --build
 
 # Stop services
-docker-compose down
+docker compose down
 
 # View logs
-docker-compose logs -f backend
+docker compose logs -f backend
 
 # Restart backend
-docker-compose up -d --build backend
+docker compose up -d --build backend
 
 # Reset everything (clears database)
-docker-compose down -v
-docker-compose up -d --build
+docker compose down -v
+docker compose up -d --build
 ```
 
 ## Troubleshooting
 
 **Container keeps restarting**
 ```bash
-docker-compose logs backend
+docker compose logs backend
 ```
 
 **Cannot connect to database**
-- Ensure SQL Server is healthy: `docker-compose ps`
+- Ensure SQL Server is healthy: `docker compose ps`
 - Wait 30 seconds after startup for initialization
 
 **Port conflict**
 ```bash
-docker-compose down
+docker compose down
 netstat -ano | findstr :8086
 ```
 
@@ -147,16 +158,17 @@ CI (GitHub Actions):
 
 ## Project Structure
 
-```
+```text
 BreastCancer/
-├── Controllers/          # API endpoints
-├── Models/               # Entity models
-├── Context/              # Database context
-├── Repository/           # Data access layer
-├── Service/              # Business logic
-├── BreastCancer.Tests/   # Unit and integration tests
-├── appsettings.json      # Local configuration
+├── Controllers/              # API endpoints
+├── Models/                   # Entity models
+├── Context/                  # Database context
+├── Repository/               # Data access layer
+├── Service/                  # Business logic
+├── BreastCancer.Tests/       # Unit and integration tests
+├── appsettings.json          # Local configuration
 ├── appsettings.Docker.json   # Docker configuration
-├── docker-compose.yml    # Docker services
+├── docker-compose.yml        # Base Docker infrastructure (standalone)
+├── docker-compose.ai.yml     # Optional AI network integration
 └── Dockerfile
 ```

--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -1,0 +1,9 @@
+services:
+  backend:
+    networks:
+      - chatbot-network
+
+networks:
+  chatbot-network:
+    external: true
+    name: ai-driven-breast-cancer-recurrence-prediction-and-support-system_default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+# version: "3.8"
 
 services:
   sql-server:
@@ -40,7 +40,6 @@ services:
     restart: unless-stopped
     networks:
       - breast-cancer-network
-      - chatbot-network
 
 volumes:
   sqlserver-data:
@@ -48,6 +47,3 @@ volumes:
 networks:
   breast-cancer-network:
     driver: bridge
-  chatbot-network:
-    external: true
-    name: ai-driven-breast-cancer-recurrence-prediction-and-support-system_default


### PR DESCRIPTION
## What does this PR do?
Separates the core backend infrastructure from the AI chatbot integration by moving the external network dependency into a dedicated Docker Compose override file.

## Why is this necessary?
Previously, running `docker-compose up -d` would fail if the external AI network (`ai-driven-breast-cancer-recurrence-prediction-and-support-system_default`) was not already running on the host machine. This prevented developers from running the core backend API independently. 

## How was this solved?
1. **Removed** the AI network requirement and obsolete `version: "3.8"` tag from `docker-compose.yml`. The core stack now runs entirely on its own internal bridge network.
2. **Created** a new `docker-compose.ai.yml` file. This acts as an opt-in override that attaches the backend to the external chatbot network.
3. **Updated** the `README.md` with modern `docker compose` syntax (dropped the hyphen) and clear instructions on how to run the stack both standalone and with AI integration.

## Testing Steps
1. Run `docker compose up -d` -> The backend and SQL server should start successfully on their own.
2. Run `docker compose -f docker-compose.yml -f docker-compose.ai.yml up -d` -> The backend should successfully attach to both the internal and external AI networks (assuming the AI network exists).