### PR TITLE
feat: implement community schema tables and migrations

### DIFF
--- a/Context/BreastCancerDB.cs
+++ b/Context/BreastCancerDB.cs
@@ -26,6 +26,10 @@ namespace BreastCancer.Context
         public virtual DbSet<NutritionMeal> NutritionMeals { get; set; }
         public virtual DbSet<MealLog> MealLogs { get; set; }
         public virtual DbSet<PatientDiagnosis> PatientDiagnoses { get; set; }
+        public virtual DbSet<Post> Posts { get; set; }
+        public virtual DbSet<Comment> Comments { get; set; }
+        public virtual DbSet<Reaction> Reactions { get; set; }
+        public virtual DbSet<Follow> Follows { get; set; }
 
 
         protected override void OnModelCreating(ModelBuilder builder)
@@ -177,6 +181,85 @@ namespace BreastCancer.Context
             builder.Entity<NutritionMeal>()
                 .Property(meal => meal.Fat)
                 .HasPrecision(10, 2);
+
+            builder.Entity<Post>()
+                .ToTable("Posts", "community")
+                .HasQueryFilter(post => !post.IsDeleted);
+
+            builder.Entity<Post>()
+                .Property(post => post.Type)
+                .HasConversion<string>()
+                .HasMaxLength(50);
+
+            builder.Entity<Post>()
+                .Property(post => post.Visibility)
+                .HasConversion<string>()
+                .HasMaxLength(50);
+
+            builder.Entity<Post>()
+                .HasOne(post => post.Author)
+                .WithMany()
+                .HasForeignKey(post => post.AuthorId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            builder.Entity<Comment>()
+                .ToTable("Comments", "community");
+
+            builder.Entity<Comment>()
+                .HasQueryFilter(comment => !comment.Post.IsDeleted);
+
+            builder.Entity<Comment>()
+                .HasOne(comment => comment.Post)
+                .WithMany(post => post.Comments)
+                .HasForeignKey(comment => comment.PostId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            builder.Entity<Comment>()
+                .HasOne(comment => comment.Author)
+                .WithMany()
+                .HasForeignKey(comment => comment.AuthorId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            builder.Entity<Reaction>()
+                .ToTable("Reactions", "community");
+
+            builder.Entity<Reaction>()
+                .HasQueryFilter(reaction => !reaction.Post.IsDeleted);
+
+            builder.Entity<Reaction>()
+                .Property(reaction => reaction.Type)
+                .HasConversion<string>()
+                .HasMaxLength(50);
+
+            builder.Entity<Reaction>()
+                .HasOne(reaction => reaction.Post)
+                .WithMany(post => post.Reactions)
+                .HasForeignKey(reaction => reaction.PostId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            builder.Entity<Reaction>()
+                .HasOne(reaction => reaction.User)
+                .WithMany()
+                .HasForeignKey(reaction => reaction.UserId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            builder.Entity<Follow>()
+                .ToTable("Follows", "community");
+
+            builder.Entity<Follow>()
+                .HasKey(follow => new { follow.FollowerId, follow.FollowingId });
+
+            builder.Entity<Follow>()
+                .HasOne(follow => follow.Follower)
+                .WithMany()
+                .HasForeignKey(follow => follow.FollowerId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            builder.Entity<Follow>()
+                .HasOne(follow => follow.Following)
+                .WithMany()
+                .HasForeignKey(follow => follow.FollowingId)
+                .OnDelete(DeleteBehavior.NoAction);
         }
 
     }

--- a/Enum/PostType.cs
+++ b/Enum/PostType.cs
@@ -1,0 +1,10 @@
+namespace BreastCancer.Enum
+{
+    public enum PostType
+    {
+        General,
+        Question,
+        Support,
+        Resource
+    }
+}

--- a/Enum/PostType.cs
+++ b/Enum/PostType.cs
@@ -2,8 +2,10 @@ namespace BreastCancer.Enum
 {
     public enum PostType
     {
-        General,
+        Story,
         Question,
+        MilestoneShare,
+        DoctorUpdate,
         Support,
         Resource
     }

--- a/Enum/PostVisibility.cs
+++ b/Enum/PostVisibility.cs
@@ -1,0 +1,9 @@
+namespace BreastCancer.Enum
+{
+    public enum PostVisibility
+    {
+        Public,
+        FollowersOnly,
+        Private
+    }
+}

--- a/Enum/PostVisibility.cs
+++ b/Enum/PostVisibility.cs
@@ -3,7 +3,9 @@ namespace BreastCancer.Enum
     public enum PostVisibility
     {
         Public,
-        FollowersOnly,
-        Private
+        PatientsOnly,
+        CaregiverOnly,
+        DoctorOnly,
+        FollowersOnly
     }
 }

--- a/Enum/ReactionType.cs
+++ b/Enum/ReactionType.cs
@@ -1,0 +1,9 @@
+namespace BreastCancer.Enum
+{
+    public enum ReactionType
+    {
+        Like,
+        Support,
+        Insightful
+    }
+}

--- a/Migrations/20260519201312_AddCommunityTables.Designer.cs
+++ b/Migrations/20260519201312_AddCommunityTables.Designer.cs
@@ -4,6 +4,7 @@ using BreastCancer.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BreastCancer.Migrations
 {
     [DbContext(typeof(BreastCancerDB))]
-    partial class BreastCancerDBModelSnapshot : ModelSnapshot
+    [Migration("20260519201312_AddCommunityTables")]
+    partial class AddCommunityTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260519201312_AddCommunityTables.cs
+++ b/Migrations/20260519201312_AddCommunityTables.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BreastCancer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommunityTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.EnsureSchema(
+                name: "community");
+
+            migrationBuilder.CreateTable(
+                name: "Follows",
+                schema: "community",
+                columns: table => new
+                {
+                    FollowerId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    FollowingId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Follows", x => new { x.FollowerId, x.FollowingId });
+                    table.ForeignKey(
+                        name: "FK_Follows_AspNetUsers_FollowerId",
+                        column: x => x.FollowerId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_Follows_AspNetUsers_FollowingId",
+                        column: x => x.FollowingId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Posts",
+                schema: "community",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    AuthorId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Content = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Type = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Visibility = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Posts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Posts_AspNetUsers_AuthorId",
+                        column: x => x.AuthorId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Comments",
+                schema: "community",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    PostId = table.Column<int>(type: "int", nullable: false),
+                    AuthorId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Content = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Comments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Comments_AspNetUsers_AuthorId",
+                        column: x => x.AuthorId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_Comments_Posts_PostId",
+                        column: x => x.PostId,
+                        principalSchema: "community",
+                        principalTable: "Posts",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Reactions",
+                schema: "community",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    PostId = table.Column<int>(type: "int", nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Type = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Reactions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Reactions_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_Reactions_Posts_PostId",
+                        column: x => x.PostId,
+                        principalSchema: "community",
+                        principalTable: "Posts",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "1",
+                column: "ConcurrencyStamp",
+                value: "28fdf492-3ed6-4a8c-99d0-09404606ad8c");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "2",
+                column: "ConcurrencyStamp",
+                value: "23439ec3-9614-4984-8cc8-ed2a52da65b0");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "3",
+                column: "ConcurrencyStamp",
+                value: "d00efb97-1c53-425d-a96b-217679bee103");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "4",
+                column: "ConcurrencyStamp",
+                value: "577a6881-0566-4837-9403-085496f7a72d");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Comments_AuthorId",
+                schema: "community",
+                table: "Comments",
+                column: "AuthorId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Comments_PostId",
+                schema: "community",
+                table: "Comments",
+                column: "PostId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Follows_FollowingId",
+                schema: "community",
+                table: "Follows",
+                column: "FollowingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Posts_AuthorId",
+                schema: "community",
+                table: "Posts",
+                column: "AuthorId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Reactions_PostId",
+                schema: "community",
+                table: "Reactions",
+                column: "PostId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Reactions_UserId",
+                schema: "community",
+                table: "Reactions",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Comments",
+                schema: "community");
+
+            migrationBuilder.DropTable(
+                name: "Follows",
+                schema: "community");
+
+            migrationBuilder.DropTable(
+                name: "Reactions",
+                schema: "community");
+
+            migrationBuilder.DropTable(
+                name: "Posts",
+                schema: "community");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "1",
+                column: "ConcurrencyStamp",
+                value: "60b0b93c-145f-4c48-868e-91b4ee464c6e");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "2",
+                column: "ConcurrencyStamp",
+                value: "23cfef64-42d8-4ce8-886b-e9b3feb05a9d");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "3",
+                column: "ConcurrencyStamp",
+                value: "5f7d13ee-3dd5-4449-bf32-f8ed926ebd2f");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "4",
+                column: "ConcurrencyStamp",
+                value: "f61befd0-11b0-4192-ad27-9f8c259b7d62");
+        }
+    }
+}

--- a/Migrations/20260519203424_UpdateCommunityEnums.Designer.cs
+++ b/Migrations/20260519203424_UpdateCommunityEnums.Designer.cs
@@ -4,6 +4,7 @@ using BreastCancer.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BreastCancer.Migrations
 {
     [DbContext(typeof(BreastCancerDB))]
-    partial class BreastCancerDBModelSnapshot : ModelSnapshot
+    [Migration("20260519203424_UpdateCommunityEnums")]
+    partial class UpdateCommunityEnums
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260519203424_UpdateCommunityEnums.cs
+++ b/Migrations/20260519203424_UpdateCommunityEnums.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BreastCancer.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateCommunityEnums : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "1",
+                column: "ConcurrencyStamp",
+                value: "4101b4e7-0fa2-49e2-a709-044af3b2b755");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "2",
+                column: "ConcurrencyStamp",
+                value: "0c7139a3-e671-4dc4-97f0-83eb70b00889");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "3",
+                column: "ConcurrencyStamp",
+                value: "ba267127-0da5-44a5-9297-0d0eb7e4e966");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "4",
+                column: "ConcurrencyStamp",
+                value: "802b2dc9-0300-493e-b1c3-0bf32df0e319");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "1",
+                column: "ConcurrencyStamp",
+                value: "28fdf492-3ed6-4a8c-99d0-09404606ad8c");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "2",
+                column: "ConcurrencyStamp",
+                value: "23439ec3-9614-4984-8cc8-ed2a52da65b0");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "3",
+                column: "ConcurrencyStamp",
+                value: "d00efb97-1c53-425d-a96b-217679bee103");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "4",
+                column: "ConcurrencyStamp",
+                value: "577a6881-0566-4837-9403-085496f7a72d");
+        }
+    }
+}

--- a/Models/Comment.cs
+++ b/Models/Comment.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace BreastCancer.Models
+{
+    public class Comment
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Required]
+        public int PostId { get; set; }
+
+        [Required]
+        public string AuthorId { get; set; } = null!;
+
+        [Required]
+        public string Content { get; set; } = null!;
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public virtual Post Post { get; set; } = null!;
+        public virtual ApplicationUser Author { get; set; } = null!;
+    }
+}

--- a/Models/Follow.cs
+++ b/Models/Follow.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BreastCancer.Models
+{
+    public class Follow
+    {
+        [Required]
+        public string FollowerId { get; set; } = null!;
+
+        [Required]
+        public string FollowingId { get; set; } = null!;
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public virtual ApplicationUser Follower { get; set; } = null!;
+        public virtual ApplicationUser Following { get; set; } = null!;
+    }
+}

--- a/Models/Post.cs
+++ b/Models/Post.cs
@@ -1,0 +1,31 @@
+using BreastCancer.Enum;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace BreastCancer.Models
+{
+    public class Post
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Required]
+        public string AuthorId { get; set; } = null!;
+
+        [Required]
+        public string Content { get; set; } = null!;
+
+        public PostType Type { get; set; } = PostType.General;
+        public PostVisibility Visibility { get; set; } = PostVisibility.Public;
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+        public bool IsDeleted { get; set; } = false;
+
+        public virtual ApplicationUser Author { get; set; } = null!;
+        public virtual ICollection<Comment> Comments { get; set; } = new List<Comment>();
+        public virtual ICollection<Reaction> Reactions { get; set; } = new List<Reaction>();
+    }
+}

--- a/Models/Post.cs
+++ b/Models/Post.cs
@@ -16,7 +16,7 @@ namespace BreastCancer.Models
         [Required]
         public string Content { get; set; } = null!;
 
-        public PostType Type { get; set; } = PostType.General;
+        public PostType Type { get; set; } = PostType.Story;
         public PostVisibility Visibility { get; set; } = PostVisibility.Public;
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/Models/Reaction.cs
+++ b/Models/Reaction.cs
@@ -1,0 +1,24 @@
+using BreastCancer.Enum;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace BreastCancer.Models
+{
+    public class Reaction
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Required]
+        public int PostId { get; set; }
+
+        [Required]
+        public string UserId { get; set; } = null!;
+
+        public ReactionType Type { get; set; } = ReactionType.Like;
+
+        public virtual Post Post { get; set; } = null!;
+        public virtual ApplicationUser User { get; set; } = null!;
+    }
+}


### PR DESCRIPTION
## What does this PR do?
Creates the Entity Framework Core entities and database migrations for the new Community feature, isolating all related tables within a dedicated `community` database schema.

## Acceptance Criteria Met
- **Dedicated Schema:** All tables are configured to live inside the `community` schema (e.g., `community.Posts`).
- **Posts Table:** Created with `Id`, `AuthorId`, `Content`, `Type` (enum), `Visibility` (enum), `CreatedAt`, `UpdatedAt`, and `IsDeleted`.
- **Comments Table:** Created with `Id`, `PostId`, `AuthorId`, `Content`, and `CreatedAt`.
- **Reactions Table:** Created with `Id`, `PostId`, `UserId`, and `Type`.
- **Follows Table:** Created with a composite primary key (`FollowerId`, `FollowingId`) and `CreatedAt`.
- **Data Integrity:** Applied global query filters to handle soft deletes on `Posts` safely, preventing cascading relationship crashes with `Comments` and `Reactions`.

## Technical Notes
- Implemented **soft delete** (`IsDeleted` flag) on the `Posts` table to comply with medical data retention and auditing requirements. 
- Set `OnDelete(DeleteBehavior.NoAction)` on foreign keys to prevent SQL Server cyclical cascade delete constraints.

## Testing Steps
1. Run the database migration locally:
   ```powershell
   dotnet ef database update