### PR TITLE
feat: implement create post endpoint with visibility rules

### DIFF
--- a/BreastCancer.Tests/Unit/CommunityPostCreatedEventTests.cs
+++ b/BreastCancer.Tests/Unit/CommunityPostCreatedEventTests.cs
@@ -1,9 +1,17 @@
+using AutoMapper;
 using BreastCancer.Community;
+using BreastCancer.Community.DTO.request;
+using BreastCancer.Community.DTO.response;
 using BreastCancer.Community.Events;
 using BreastCancer.Community.Features;
+using BreastCancer.Enum;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
 using FluentAssertions;
 using MediatR;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Xunit;
 
 namespace BreastCancer.Tests.Unit;
@@ -17,17 +25,60 @@ public sealed class CommunityPostCreatedEventTests
         services.AddLogging();
         services.AddCommunityModule();
 
+        var mapper = new Mock<IMapper>();
+        mapper.Setup(m => m.Map<Post>(It.IsAny<CreatePostDTO>()))
+            .Returns<CreatePostDTO>(dto => new Post
+            {
+                Content = dto.Content,
+                Type = dto.Type,
+                Visibility = dto.Visibility,
+                MediaUrls = dto.MediaUrls ?? new List<string>()
+            });
+        mapper.Setup(m => m.Map<PostDTO>(It.IsAny<Post>()))
+            .Returns<Post>(post => new PostDTO
+            {
+                Id = post.Id,
+                AuthorId = post.AuthorId,
+                Content = post.Content,
+                PostType = post.Type,
+                PostVisibility = post.Visibility,
+                MediaUrls = post.MediaUrls,
+                CreatedAt = post.CreatedAt
+            });
+        services.AddSingleton(mapper.Object);
+
+        var postRepository = new Mock<IPostRepository>();
+        postRepository.Setup(r => r.AddAsync(It.IsAny<Post>()))
+            .Callback<Post>(post => post.Id = 42)
+            .Returns(Task.CompletedTask);
+
+        var transaction = new Mock<IDbContextTransaction>();
+        var unitOfWork = new Mock<IUnitOfWork>();
+        unitOfWork.SetupGet(u => u.PostRepository).Returns(postRepository.Object);
+        unitOfWork.Setup(u => u.BeginTransactionAsync()).ReturnsAsync(transaction.Object);
+        unitOfWork.Setup(u => u.SaveAsync()).ReturnsAsync(1);
+        services.AddSingleton(unitOfWork.Object);
+
         var recorder = new InMemoryPostCreatedEventSink();
         services.AddScoped<IPostCreatedEventSink>(_ => recorder);
 
         var provider = services.BuildServiceProvider();
         var mediator = provider.GetRequiredService<IMediator>();
 
-        var createdPostId = await mediator.Send(new CreatePostCommand("author-1"));
+        var createdPost = await mediator.Send(new CreatePostCommand(
+            new CreatePostDTO
+            {
+                Content = "Hello",
+                Type = PostType.Story,
+                Visibility = PostVisibility.Public
+            },
+            "author-1",
+            new[] { "Doctor" }));
 
         recorder.Events.Should().ContainSingle();
-        recorder.Events[0].PostId.Should().Be(createdPostId);
+        recorder.Events[0].PostId.Should().Be(createdPost.Id);
         recorder.Events[0].AuthorId.Should().Be("author-1");
+        recorder.Events[0].Visibility.Should().Be(PostVisibility.Public);
     }
 
     private sealed class InMemoryPostCreatedEventSink : IPostCreatedEventSink

--- a/BreastCancer.Tests/Unit/CreatePostCommandHandlerTests.cs
+++ b/BreastCancer.Tests/Unit/CreatePostCommandHandlerTests.cs
@@ -1,0 +1,123 @@
+using BreastCancer.Community.DTO.request;
+using BreastCancer.Community.Exceptions;
+using BreastCancer.Community.Features;
+using BreastCancer.Enum;
+using AutoMapper;
+using BreastCancer.Community.DTO.response;
+using BreastCancer.Community.Events;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace BreastCancer.Tests.Unit;
+
+public sealed class CreatePostCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenNonDoctorCreatesDoctorUpdate_ThrowsForbidden()
+    {
+        var sut = CreateSut();
+        var command = new CreatePostCommand(
+            new CreatePostDTO
+            {
+                Content = "Doctor update",
+                Type = PostType.DoctorUpdate,
+                Visibility = PostVisibility.Public
+            },
+            "author-1",
+            new[] { "Patient" });
+
+        var act = async () => await sut.Handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<PostAccessForbiddenException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenDoctorCreatesDoctorUpdate_SavesAndPublishes()
+    {
+        var sut = CreateSut();
+        var command = new CreatePostCommand(
+            new CreatePostDTO
+            {
+                Content = "Doctor update",
+                Type = PostType.DoctorUpdate,
+                Visibility = PostVisibility.DoctorOnly,
+                MediaUrls = new List<string> { "https://media" }
+            },
+            "doctor-1",
+            new[] { "Doctor" });
+
+        var result = await sut.Handler.Handle(command, CancellationToken.None);
+
+        result.AuthorId.Should().Be("doctor-1");
+        result.PostType.Should().Be(PostType.DoctorUpdate);
+        result.PostVisibility.Should().Be(PostVisibility.DoctorOnly);
+        result.MediaUrls.Should().ContainSingle("https://media");
+        sut.Publisher.Verify(p => p.Publish(It.IsAny<PostCreatedEvent>(), It.IsAny<CancellationToken>()), Times.Once);
+        sut.UnitOfWork.Verify(u => u.SaveAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNonDoctorCreatesStory_AllowsCreation()
+    {
+        var sut = CreateSut();
+        var command = new CreatePostCommand(
+            new CreatePostDTO
+            {
+                Content = "Story",
+                Type = PostType.Story,
+                Visibility = PostVisibility.Public
+            },
+            "patient-1",
+            new[] { "Patient" });
+
+        var result = await sut.Handler.Handle(command, CancellationToken.None);
+
+        result.AuthorId.Should().Be("patient-1");
+        result.PostType.Should().Be(PostType.Story);
+        sut.Publisher.Verify(p => p.Publish(It.IsAny<PostCreatedEvent>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static Sut CreateSut()
+    {
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var repository = new Mock<IPostRepository>();
+        var publisher = new Mock<IPublisher>();
+        var transaction = new Mock<Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction>();
+
+        var mapper = new Mock<IMapper>();
+        mapper.Setup(m => m.Map<Post>(It.IsAny<CreatePostDTO>()))
+            .Returns<CreatePostDTO>(dto => new Post
+            {
+                Content = dto.Content,
+                Type = dto.Type,
+                Visibility = dto.Visibility,
+                MediaUrls = dto.MediaUrls ?? new List<string>()
+            });
+        mapper.Setup(m => m.Map<PostDTO>(It.IsAny<Post>()))
+            .Returns<Post>(post => new PostDTO
+            {
+                Id = post.Id,
+                AuthorId = post.AuthorId,
+                Content = post.Content,
+                PostType = post.Type,
+                PostVisibility = post.Visibility,
+                MediaUrls = post.MediaUrls,
+                CreatedAt = post.CreatedAt
+            });
+
+        unitOfWork.SetupGet(u => u.PostRepository).Returns(repository.Object);
+        unitOfWork.Setup(u => u.BeginTransactionAsync()).ReturnsAsync(transaction.Object);
+        unitOfWork.Setup(u => u.SaveAsync()).ReturnsAsync(1);
+
+        repository.Setup(r => r.AddAsync(It.IsAny<Post>())).Returns(Task.CompletedTask);
+
+        var handler = new CreatePostCommandHandler(mapper.Object, publisher.Object, unitOfWork.Object);
+        return new Sut(handler, unitOfWork, publisher);
+    }
+
+    private sealed record Sut(CreatePostCommandHandler Handler, Mock<IUnitOfWork> UnitOfWork, Mock<IPublisher> Publisher);
+}

--- a/BreastCancer.Tests/Unit/CreatePostCommandValidatorTests.cs
+++ b/BreastCancer.Tests/Unit/CreatePostCommandValidatorTests.cs
@@ -1,0 +1,77 @@
+using BreastCancer.Community.DTO.request;
+using BreastCancer.Community.Features;
+using BreastCancer.Enum;
+using FluentAssertions;
+using Xunit;
+namespace BreastCancer.Tests.Unit;
+
+public sealed class CreatePostCommandValidatorTests
+{
+    private readonly CreatePostCommandValidator _validator = new();
+
+    [Fact]
+    public void Validate_WhenContentTooLong_ReturnsError()
+    {
+        var content = new string('a', 2001);
+        var command = CreateCommand(new CreatePostDTO
+        {
+            Content = content,
+            Type = PostType.Story,
+            Visibility = PostVisibility.Public
+        });
+
+        var result = _validator.Validate(command);
+
+        result.Errors.Should().Contain(error => error.PropertyName == "Post.Content");
+    }
+
+    [Fact]
+    public void Validate_WhenTooManyMediaUrls_ReturnsError()
+    {
+        var command = CreateCommand(new CreatePostDTO
+        {
+            Content = "Hello",
+            Type = PostType.Story,
+            Visibility = PostVisibility.Public,
+            MediaUrls = new List<string> { "https://one", "https://two", "https://three", "https://four", "https://five" }
+        });
+
+        var result = _validator.Validate(command);
+
+        result.Errors.Should().Contain(error => error.PropertyName == "Post.MediaUrls");
+    }
+
+    [Fact]
+    public void Validate_WhenMediaUrlInvalid_ReturnsError()
+    {
+        var command = CreateCommand(new CreatePostDTO
+        {
+            Content = "Hello",
+            Type = PostType.Story,
+            Visibility = PostVisibility.Public,
+            MediaUrls = new List<string> { "not-a-url" }
+        });
+
+        var result = _validator.Validate(command);
+
+        result.Errors.Should().Contain(error => error.PropertyName == "Post.MediaUrls[0]");
+    }
+
+    [Fact]
+    public void Validate_WhenVisibilityNotAllowed_ReturnsError()
+    {
+        var command = CreateCommand(new CreatePostDTO
+        {
+            Content = "Hello",
+            Type = PostType.Story,
+            Visibility = PostVisibility.FollowersOnly
+        });
+
+        var result = _validator.Validate(command);
+
+        result.Errors.Should().Contain(error => error.PropertyName == "Post.Visibility");
+    }
+
+    private static CreatePostCommand CreateCommand(CreatePostDTO dto)
+        => new(dto, "author-1", new[] { "Doctor" });
+}

--- a/Community/Controllers/CommunityController.cs
+++ b/Community/Controllers/CommunityController.cs
@@ -2,6 +2,7 @@
 using BreastCancer.Community.Exceptions;
 using BreastCancer.Community.Features;
 using BreastCancer.Community.Security;
+using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -41,6 +42,15 @@ namespace BreastCancer.Community.Controllers
             {
                 var post = await mediator.Send(new CreatePostCommand(createPostDTO, userId, roles));
                 return StatusCode(StatusCodes.Status201Created, post);
+            }
+            catch (ValidationException ex)
+            {
+                var errors = ex.Errors.Select(error => new
+                {
+                    field = error.PropertyName,
+                    message = error.ErrorMessage
+                });
+                return BadRequest(new { errors });
             }
             catch (PostAccessForbiddenException ex)
             {

--- a/Community/Controllers/CommunityController.cs
+++ b/Community/Controllers/CommunityController.cs
@@ -1,0 +1,52 @@
+﻿using BreastCancer.Community.DTO.request;
+using BreastCancer.Community.Exceptions;
+using BreastCancer.Community.Features;
+using BreastCancer.Community.Security;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace BreastCancer.Community.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class CommunityController : ControllerBase
+    {
+        private readonly IMediator mediator;
+
+        public CommunityController(IMediator mediator)
+        {
+            this.mediator = mediator;
+        }
+
+        [HttpPost("posts")]
+        [Authorize]
+        [SwaggerOperation(Summary = "Create a community post")]
+        [SwaggerResponse(StatusCodes.Status201Created, "Post created successfully")]
+        [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized access")]
+        [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - user role not allowed")]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation error")]
+        public async Task<IActionResult> CreatePost([FromBody] CreatePostDTO createPostDTO)
+        {
+            var userId = User.GetUserId();
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return Unauthorized(new { message = "Could not identify user" });
+            }
+
+            var roles = User.GetRoles();
+            try
+            {
+                var post = await mediator.Send(new CreatePostCommand(createPostDTO, userId, roles));
+                return StatusCode(StatusCodes.Status201Created, post);
+            }
+            catch (PostAccessForbiddenException ex)
+            {
+                return StatusCode(StatusCodes.Status403Forbidden, new { message = ex.Message });
+            }
+        }
+
+    }
+}

--- a/Community/DTO/request/CreatePostDTO.cs
+++ b/Community/DTO/request/CreatePostDTO.cs
@@ -1,0 +1,21 @@
+﻿using BreastCancer.Enum;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace BreastCancer.Community.DTO.request
+{
+    public class CreatePostDTO
+    {
+        [Required]
+        [StringLength(2000, MinimumLength = 1, ErrorMessage = "Content must be between 1 and 2000 characters")]
+        public string Content { get; set; }
+        [Required]
+        [EnumDataType(typeof(PostType), ErrorMessage = "Invalid Post Type")]
+        public PostType Type { get; set; }
+        [Required]
+        [EnumDataType(typeof(PostVisibility), ErrorMessage = "Invalid Post Visibility")]
+        public PostVisibility Visibility { get; set; }
+        [JsonPropertyName("mediaUrls")]
+        public List<string>? MediaUrls { get; set; }
+    }
+}

--- a/Community/DTO/response/PostDTO.cs
+++ b/Community/DTO/response/PostDTO.cs
@@ -1,0 +1,17 @@
+﻿using BreastCancer.Enum;
+using System.Text.Json.Serialization;
+
+namespace BreastCancer.Community.DTO.response
+{
+    public class PostDTO
+    {
+        public int Id { get; set; }
+        public string AuthorId { get; set; }
+        public string Content { get; set; }
+        public PostType PostType { get; set; }
+        public PostVisibility PostVisibility { get; set; }
+        [JsonPropertyName("mediaUrls")]
+        public IReadOnlyCollection<string>? MediaUrls { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Community/Events/PostCreatedEvent.cs
+++ b/Community/Events/PostCreatedEvent.cs
@@ -1,5 +1,6 @@
 using BreastCancer.Community.Domain;
+using BreastCancer.Enum;
 
 namespace BreastCancer.Community.Events;
 
-public sealed record PostCreatedEvent(int PostId, string AuthorId) : DomainEvent;
+public sealed record PostCreatedEvent(int PostId, string AuthorId, PostVisibility Visibility) : DomainEvent;

--- a/Community/Exceptions/PostAccessForbiddenException.cs
+++ b/Community/Exceptions/PostAccessForbiddenException.cs
@@ -1,0 +1,15 @@
+using System.Runtime.Serialization;
+
+namespace BreastCancer.Community.Exceptions;
+
+[Serializable]
+public sealed class PostAccessForbiddenException : Exception
+{
+    public PostAccessForbiddenException(string message) : base(message)
+    {
+    }
+
+    private PostAccessForbiddenException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+}

--- a/Community/Features/CreatePostCommand.cs
+++ b/Community/Features/CreatePostCommand.cs
@@ -1,5 +1,7 @@
+using BreastCancer.Community.DTO.request;
+using BreastCancer.Community.DTO.response;
 using MediatR;
 
 namespace BreastCancer.Community.Features;
 
-public sealed record CreatePostCommand(string AuthorId) : IRequest<int>;
+public sealed record CreatePostCommand(CreatePostDTO Post, string AuthorId, IReadOnlyCollection<string> Roles) : IRequest<PostDTO>;

--- a/Community/Features/CreatePostCommandHandler.cs
+++ b/Community/Features/CreatePostCommandHandler.cs
@@ -25,6 +25,8 @@ public sealed class CreatePostCommandHandler : IRequestHandler<CreatePostCommand
     public async Task<PostDTO> Handle(CreatePostCommand request, CancellationToken cancellationToken)
     {
         await using var transaction = await _unitOfWork.BeginTransactionAsync();
+        var committed = false;
+        Post post;
         try
         {
             if (request.Post.Type == PostType.DoctorUpdate
@@ -33,7 +35,7 @@ public sealed class CreatePostCommandHandler : IRequestHandler<CreatePostCommand
                 throw new PostAccessForbiddenException("Only doctors can create DoctorUpdate posts.");
             }
 
-            var post = _mapper.Map<Models.Post>(request.Post);
+            post = _mapper.Map<Post>(request.Post);
             post.AuthorId = request.AuthorId;
             post.MediaUrls = request.Post.MediaUrls ?? new List<string>();
 
@@ -42,15 +44,19 @@ public sealed class CreatePostCommandHandler : IRequestHandler<CreatePostCommand
             await _unitOfWork.SaveAsync();
 
             await transaction.CommitAsync();
-
-            await _publisher.Publish(new PostCreatedEvent(post.Id, post.AuthorId, post.Visibility), cancellationToken);
-
-            return _mapper.Map<PostDTO>(post);
+            committed = true;
         }
         catch
         {
-            await transaction.RollbackAsync();
+            if (!committed)
+            {
+                await transaction.RollbackAsync();
+            }
             throw;
         }
+
+        await _publisher.Publish(new PostCreatedEvent(post.Id, post.AuthorId, post.Visibility), cancellationToken);
+
+        return _mapper.Map<PostDTO>(post);
     }
 }

--- a/Community/Features/CreatePostCommandHandler.cs
+++ b/Community/Features/CreatePostCommandHandler.cs
@@ -1,21 +1,56 @@
+using AutoMapper;
+using BreastCancer.Community.DTO.response;
 using BreastCancer.Community.Events;
+using BreastCancer.Community.Exceptions;
+using BreastCancer.Enum;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
 using MediatR;
 
 namespace BreastCancer.Community.Features;
 
-public sealed class CreatePostCommandHandler : IRequestHandler<CreatePostCommand, int>
+public sealed class CreatePostCommandHandler : IRequestHandler<CreatePostCommand, PostDTO>
 {
+    private readonly IMapper _mapper;
     private readonly IPublisher _publisher;
+    private readonly IUnitOfWork _unitOfWork;
 
-    public CreatePostCommandHandler(IPublisher publisher)
+    public CreatePostCommandHandler(IMapper mapper, IPublisher publisher, IUnitOfWork unitOfWork)
     {
+        _mapper = mapper;
         _publisher = publisher;
+        _unitOfWork = unitOfWork;
     }
 
-    public async Task<int> Handle(CreatePostCommand request, CancellationToken cancellationToken)
+    public async Task<PostDTO> Handle(CreatePostCommand request, CancellationToken cancellationToken)
     {
-        const int postId = 0; // TODO: Implement actual post creation logic and generate a real post ID
-        await _publisher.Publish(new PostCreatedEvent(postId, request.AuthorId), cancellationToken);
-        return postId;
+        await using var transaction = await _unitOfWork.BeginTransactionAsync();
+        try
+        {
+            if (request.Post.Type == PostType.DoctorUpdate
+                && !request.Roles.Any(role => role.Equals("Doctor", StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new PostAccessForbiddenException("Only doctors can create DoctorUpdate posts.");
+            }
+
+            var post = _mapper.Map<Models.Post>(request.Post);
+            post.AuthorId = request.AuthorId;
+            post.MediaUrls = request.Post.MediaUrls ?? new List<string>();
+
+            await _unitOfWork.PostRepository.AddAsync(post);
+
+            await _unitOfWork.SaveAsync();
+
+            await transaction.CommitAsync();
+
+            await _publisher.Publish(new PostCreatedEvent(post.Id, post.AuthorId, post.Visibility), cancellationToken);
+
+            return _mapper.Map<PostDTO>(post);
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
     }
 }

--- a/Community/Features/CreatePostCommandValidator.cs
+++ b/Community/Features/CreatePostCommandValidator.cs
@@ -1,0 +1,34 @@
+using BreastCancer.Enum;
+using FluentValidation;
+
+namespace BreastCancer.Community.Features;
+
+public sealed class CreatePostCommandValidator : AbstractValidator<CreatePostCommand>
+{
+    public CreatePostCommandValidator()
+    {
+        RuleFor(command => command.AuthorId)
+            .NotEmpty();
+
+        RuleFor(command => command.Post.Content)
+            .NotEmpty()
+            .MaximumLength(2000);
+
+        RuleFor(command => command.Post.MediaUrls)
+            .Must(media => media == null || media.Count <= 4)
+            .WithMessage("A post can have a maximum of 4 media items");
+
+        RuleForEach(command => command.Post.MediaUrls)
+            .NotEmpty()
+            .Must(uri => Uri.TryCreate(uri, UriKind.Absolute, out _))
+            .WithMessage("Invalid media URL format");
+
+        RuleFor(command => command.Post.Type)
+            .Must(type => type is PostType.Story or PostType.Question or PostType.MilestoneShare or PostType.DoctorUpdate)
+            .WithMessage("Invalid Post Type");
+
+        RuleFor(command => command.Post.Visibility)
+            .Must(visibility => visibility is PostVisibility.Public or PostVisibility.PatientsOnly or PostVisibility.CaregiverOnly or PostVisibility.DoctorOnly)
+            .WithMessage("Invalid Post Visibility");
+    }
+}

--- a/Community/Security/ClaimsPrincipalExtensions.cs
+++ b/Community/Security/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,21 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
+namespace BreastCancer.Community.Security;
+
+public static class ClaimsPrincipalExtensions
+{
+    public static string? GetUserId(this ClaimsPrincipal principal)
+    {
+        return principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+    }
+
+    public static IReadOnlyCollection<string> GetRoles(this ClaimsPrincipal principal)
+    {
+        return principal.FindAll(ClaimTypes.Role)
+            .Select(role => role.Value)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+}

--- a/Context/BreastCancerDB.cs
+++ b/Context/BreastCancerDB.cs
@@ -197,6 +197,14 @@ namespace BreastCancer.Context
                 .HasMaxLength(50);
 
             builder.Entity<Post>()
+                .Property(post => post.MediaUrls)
+                .HasConversion(
+                    urls => System.Text.Json.JsonSerializer.Serialize(urls, (System.Text.Json.JsonSerializerOptions?)null),
+                    json => string.IsNullOrWhiteSpace(json)
+                        ? new List<string>()
+                        : System.Text.Json.JsonSerializer.Deserialize<List<string>>(json) ?? new List<string>());
+
+            builder.Entity<Post>()
                 .HasOne(post => post.Author)
                 .WithMany()
                 .HasForeignKey(post => post.AuthorId)

--- a/Mapping/MappingProfile.cs
+++ b/Mapping/MappingProfile.cs
@@ -1,4 +1,6 @@
 using AutoMapper;
+using BreastCancer.Community.DTO.request;
+using BreastCancer.Community.DTO.response;
 using BreastCancer.DTO.request;
 using BreastCancer.DTO.response;
 using BreastCancer.Models;
@@ -214,6 +216,25 @@ namespace BreastCancer.Mapping
             CreateMap<PatientContext, PatientDiagnosis>()
                 .ForMember(dest => dest.UserId, opt => opt.Ignore())
                 .ForMember(dest => dest.Patient, opt => opt.Ignore());
+
+            #endregion
+
+            #region Community Mapping
+
+            CreateMap<CreatePostDTO, Post>()
+                .ForMember(dest => dest.AuthorId, opt => opt.Ignore())
+                .ForMember(dest => dest.MediaUrls, opt => opt.Ignore())
+                .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.IsDeleted, opt => opt.Ignore())
+                .ForMember(dest => dest.Author, opt => opt.Ignore())
+                .ForMember(dest => dest.Comments, opt => opt.Ignore())
+                .ForMember(dest => dest.Reactions, opt => opt.Ignore());
+
+            CreateMap<Post, PostDTO>()
+                .ForMember(dest => dest.PostType, opt => opt.MapFrom(src => src.Type))
+                .ForMember(dest => dest.PostVisibility, opt => opt.MapFrom(src => src.Visibility))
+                .ForMember(dest => dest.MediaUrls, opt => opt.MapFrom(src => src.MediaUrls));
 
             #endregion
         }

--- a/Migrations/20260522002115_AddPostImageUrls.Designer.cs
+++ b/Migrations/20260522002115_AddPostImageUrls.Designer.cs
@@ -4,6 +4,7 @@ using BreastCancer.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BreastCancer.Migrations
 {
     [DbContext(typeof(BreastCancerDB))]
-    partial class BreastCancerDBModelSnapshot : ModelSnapshot
+    [Migration("20260522002115_AddPostImageUrls")]
+    partial class AddPostImageUrls
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260522002115_AddPostImageUrls.cs
+++ b/Migrations/20260522002115_AddPostImageUrls.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BreastCancer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPostImageUrls : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MediaUrls",
+                schema: "community",
+                table: "Posts",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "1",
+                column: "ConcurrencyStamp",
+                value: "7c799eee-aba0-443c-aa2d-05f5d35081d6");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "2",
+                column: "ConcurrencyStamp",
+                value: "69644a95-2c23-424c-b8a3-d85e0916d2c2");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "3",
+                column: "ConcurrencyStamp",
+                value: "05312799-b7e7-4978-a7d8-42faa3d15635");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "4",
+                column: "ConcurrencyStamp",
+                value: "49fecccc-4757-4790-b585-3816b28f7c28");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MediaUrls",
+                schema: "community",
+                table: "Posts");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "1",
+                column: "ConcurrencyStamp",
+                value: "4101b4e7-0fa2-49e2-a709-044af3b2b755");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "2",
+                column: "ConcurrencyStamp",
+                value: "0c7139a3-e671-4dc4-97f0-83eb70b00889");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "3",
+                column: "ConcurrencyStamp",
+                value: "ba267127-0da5-44a5-9297-0d0eb7e4e966");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "4",
+                column: "ConcurrencyStamp",
+                value: "802b2dc9-0300-493e-b1c3-0bf32df0e319");
+        }
+    }
+}

--- a/Models/Post.cs
+++ b/Models/Post.cs
@@ -18,6 +18,7 @@ namespace BreastCancer.Models
 
         public PostType Type { get; set; } = PostType.Story;
         public PostVisibility Visibility { get; set; } = PostVisibility.Public;
+        public List<string> MediaUrls { get; set; } = new();
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;

--- a/Repository/Interface/IPostRepository.cs
+++ b/Repository/Interface/IPostRepository.cs
@@ -1,0 +1,8 @@
+﻿using BreastCancer.Models;
+
+namespace BreastCancer.Repository.Interface
+{
+    public interface IPostRepository : IGenericRepository<Post>
+    {
+    }
+}

--- a/Repository/Interface/IUnitOfWork.cs
+++ b/Repository/Interface/IUnitOfWork.cs
@@ -11,6 +11,7 @@ namespace BreastCancer.Repository.Interface
         IRefreshTokenRepository RefreshTokenRepository { get; }
 
         IPatientDiagnosisRepository PatientDiagnosisRepository { get; }
+        IPostRepository PostRepository { get; }
 
         Task<IDbContextTransaction> BeginTransactionAsync();
 

--- a/Repository/Repositories/PostRepository.cs
+++ b/Repository/Repositories/PostRepository.cs
@@ -1,0 +1,13 @@
+﻿using BreastCancer.Context;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
+
+namespace BreastCancer.Repository.Repositories
+{
+    public class PostRepository : GenericRepository<Post>, IPostRepository
+    {
+        public PostRepository(BreastCancerDB _Context) : base(_Context)
+        {
+        }
+    }
+}

--- a/Repository/Repositories/UnitOfWork.cs
+++ b/Repository/Repositories/UnitOfWork.cs
@@ -16,6 +16,7 @@ namespace BreastCancer.Repository.Repositories
         private ITreatmentPlanRepository _treatmentPlansRepository;
         private IRefreshTokenRepository _refreshTokenRepository;
         private IPatientDiagnosisRepository _patientDiagnosisRepository;
+        private IPostRepository _postRepository;
 
         public UnitOfWork(BreastCancerDB Context)
         {
@@ -89,6 +90,18 @@ namespace BreastCancer.Repository.Repositories
                     _patientDiagnosisRepository = new PatientDiagnosisRepository(context);
                 }
                 return _patientDiagnosisRepository;
+            }
+        }
+
+        public IPostRepository PostRepository
+        {
+            get
+            {
+                if (_postRepository == null)
+                {
+                    _postRepository = new PostRepository(context);
+                }
+                return _postRepository;
             }
         }
 


### PR DESCRIPTION
Resolves #101

# Overview
This PR implements the authenticated `Create Post` flow for the Community module, ensuring that posts are strictly validated and that visibility rules are enforced based on the user's role. 

# Key Changes
* **Authentication & Identity:** The endpoint now explicitly extracts the `AuthorId` and roles directly from the authenticated `ClaimsPrincipal`, removing the vulnerability of caller-supplied IDs.
* **Validation Pipeline:** Enforces a maximum of 2000 characters for content, limits media attachments to 4 valid URLs, and strictly checks allowed `PostTypes` and `Visibility` levels.
* **Role-Based Restrictions:** Enforces the `DoctorUpdate` restriction; if a non-doctor attempts to post this type, the handler throws a `PostAccessForbiddenException`, which the controller gracefully maps to a `403 Forbidden`.
* **Domain Events:** Successfully persists the post and publishes the `PostCreatedEvent` containing the ID, Author, and Visibility for downstream background processing.

# Testing
* Added robust unit testing for FluentValidation constraints (`CreatePostCommandValidatorTests`).
* Added isolated handler tests (`CreatePostCommandHandlerTests`) mocking AutoMapper to verify role rejections and successful saves.
* All local builds and tests pass successfully.