### PR TITLE
feat: implement follow and unfollow endpoints

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -41,7 +41,7 @@ jobs:
           /p:CoverletOutput=./TestResults/coverage-scoped/
           /p:CoverletOutputFormat=cobertura
           /p:ExcludeByFile="**/Migrations/**%2c**/*.Designer.cs%2c**/Program.cs%2c**/Context/**%2c**/Templates/**"
-          /p:Threshold=35
+          /p:Threshold=40
           /p:ThresholdType=line
           /p:ThresholdStat=total
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,7 @@
         "/p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage-scoped/",
         "/p:CoverletOutputFormat=cobertura",
         "/p:ExcludeByFile=\"**/Migrations/**%2c**/*.Designer.cs%2c**/Program.cs%2c**/Context/**%2c**/Templates/**\"",
-        "/p:Threshold=35",
+        "/p:Threshold=40",
         "/p:ThresholdType=line",
         "/p:ThresholdStat=total"
       ],

--- a/BreastCancer.Tests/Unit/FollowUserCommandHandlerTests.cs
+++ b/BreastCancer.Tests/Unit/FollowUserCommandHandlerTests.cs
@@ -1,0 +1,63 @@
+using BreastCancer.Community.Events;
+using BreastCancer.Community.Exceptions;
+using BreastCancer.Community.Features;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace BreastCancer.Tests.Unit;
+
+public sealed class FollowUserCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenAlreadyFollowing_ThrowsAlreadyFollowing()
+    {
+        var sut = CreateSut(existingFollow: true);
+        var command = new FollowUserCommand("user-1", "user-2");
+
+        var act = async () => await sut.Handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<AlreadyFollowingException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenNewFollow_SavesAndPublishes()
+    {
+        var sut = CreateSut(existingFollow: false);
+        var command = new FollowUserCommand("user-1", "user-2");
+
+        var result = await sut.Handler.Handle(command, CancellationToken.None);
+
+        result.Should().Be(MediatR.Unit.Value);
+        sut.UnitOfWork.Verify(u => u.SaveAsync(), Times.Once);
+        sut.Publisher.Verify(p => p.Publish(It.IsAny<FollowCreatedEvent>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static Sut CreateSut(bool existingFollow)
+    {
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var repository = new Mock<IFollowRepository>();
+        var publisher = new Mock<IPublisher>();
+        var transaction = new Mock<Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction>();
+
+        var existing = existingFollow
+            ? new List<Follow> { new() { FollowerId = "user-1", FollowingId = "user-2" } }
+            : new List<Follow>();
+
+        repository.Setup(r => r.FilterAsync(It.IsAny<System.Linq.Expressions.Expression<Func<Follow, bool>>>(), It.IsAny<Func<System.Linq.IQueryable<Follow>, System.Linq.IOrderedQueryable<Follow>>>(), It.IsAny<int?>(), It.IsAny<int?>()))
+            .ReturnsAsync(existing);
+        repository.Setup(r => r.AddAsync(It.IsAny<Follow>())).Returns(Task.CompletedTask);
+
+        unitOfWork.SetupGet(u => u.FollowRepository).Returns(repository.Object);
+        unitOfWork.Setup(u => u.SaveAsync()).ReturnsAsync(1);
+        unitOfWork.Setup(u => u.BeginTransactionAsync()).ReturnsAsync(transaction.Object);
+
+        var handler = new FollowUserCommandHandler(publisher.Object, unitOfWork.Object);
+        return new Sut(handler, unitOfWork, publisher);
+    }
+
+    private sealed record Sut(FollowUserCommandHandler Handler, Mock<IUnitOfWork> UnitOfWork, Mock<IPublisher> Publisher);
+}

--- a/BreastCancer.Tests/Unit/UnfollowUserCommandHandlerTests.cs
+++ b/BreastCancer.Tests/Unit/UnfollowUserCommandHandlerTests.cs
@@ -1,0 +1,57 @@
+using BreastCancer.Community.Exceptions;
+using BreastCancer.Community.Features;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace BreastCancer.Tests.Unit;
+
+public sealed class UnfollowUserCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenFollowMissing_ThrowsNotFound()
+    {
+        var sut = CreateSut(new List<Follow>());
+        var command = new UnfollowUserCommand("user-1", "user-2");
+
+        var act = async () => await sut.Handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<UserNotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenFollowExists_Deletes()
+    {
+        var existing = new Follow { FollowerId = "user-1", FollowingId = "user-2" };
+        var sut = CreateSut(new List<Follow> { existing });
+        var command = new UnfollowUserCommand("user-1", "user-2");
+
+        var result = await sut.Handler.Handle(command, CancellationToken.None);
+
+        result.Should().Be(MediatR.Unit.Value);
+        sut.Repository.Verify(r => r.Delete(existing), Times.Once);
+        sut.UnitOfWork.Verify(u => u.SaveAsync(), Times.Once);
+    }
+
+    private static Sut CreateSut(List<Follow> existing)
+    {
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var repository = new Mock<IFollowRepository>();
+
+        repository.Setup(r => r.FilterAsync(It.IsAny<System.Linq.Expressions.Expression<Func<Follow, bool>>>(), It.IsAny<Func<System.Linq.IQueryable<Follow>, System.Linq.IOrderedQueryable<Follow>>>(), It.IsAny<int?>(), It.IsAny<int?>()))
+            .ReturnsAsync(existing);
+
+        unitOfWork.SetupGet(u => u.FollowRepository).Returns(repository.Object);
+        unitOfWork.Setup(u => u.SaveAsync()).ReturnsAsync(1);
+        var transaction = new Mock<Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction>();
+        unitOfWork.Setup(u => u.BeginTransactionAsync()).ReturnsAsync(transaction.Object);
+
+        var handler = new UnfollowUserCommandHandler(unitOfWork.Object);
+        return new Sut(handler, unitOfWork, repository);
+    }
+
+    private sealed record Sut(UnfollowUserCommandHandler Handler, Mock<IUnitOfWork> UnitOfWork, Mock<IFollowRepository> Repository);
+}

--- a/Community/CommunityModule.cs
+++ b/Community/CommunityModule.cs
@@ -18,6 +18,7 @@ public static class CommunityModule
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
         services.AddScoped<IPostCreatedEventSink, NoOpPostCreatedEventSink>();
+        services.AddScoped<IFollowCreatedEventSink, NoOpFollowCreatedEventSink>();
 
         return services;
     }

--- a/Community/Controllers/CommunityController.cs
+++ b/Community/Controllers/CommunityController.cs
@@ -58,5 +58,77 @@ namespace BreastCancer.Community.Controllers
             }
         }
 
+        [HttpPost("users/{userId}/follow")]
+        [Authorize]
+        [SwaggerOperation(Summary = "Follow a user")]
+        [SwaggerResponse(StatusCodes.Status200OK, "User followed successfully")]
+        [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized access")]
+        [SwaggerResponse(StatusCodes.Status404NotFound, "User not found")]
+        [SwaggerResponse(StatusCodes.Status409Conflict, "Already following the user")]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation error")]
+        public async Task<IActionResult> FollowUser([FromRoute] string userId)
+        {
+            var followerId = User.GetUserId();
+            if (string.IsNullOrWhiteSpace(followerId))
+            {
+                return Unauthorized(new { message = "Could not identify user" });
+            }
+            try
+            {
+                await mediator.Send(new FollowUserCommand(followerId, userId));
+                return Ok(new { message = "User followed successfully" });
+            }
+            catch (ValidationException ex)
+            {
+                var errors = ex.Errors.Select(error => new
+                {
+                    field = error.PropertyName,
+                    message = error.ErrorMessage
+                });
+                return BadRequest(new { errors });
+            }
+            catch (UserNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+            catch (AlreadyFollowingException ex)
+            {
+                return Conflict(new { message = ex.Message });
+            }
+        }
+
+        [HttpDelete("users/{userId}/follow")]
+        [Authorize]
+        [SwaggerOperation(Summary = "Unfollow a user")]
+        [SwaggerResponse(StatusCodes.Status200OK, "User unfollowed successfully")]
+        [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized access")]
+        [SwaggerResponse(StatusCodes.Status404NotFound, "Follow relationship not found")]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation error")]
+        public async Task<IActionResult> UnfollowUser([FromRoute] string userId)
+        {
+            var followerId = User.GetUserId();
+            if (string.IsNullOrWhiteSpace(followerId))
+            {
+                return Unauthorized(new { message = "Could not identify user" });
+            }
+            try
+            {
+                await mediator.Send(new UnfollowUserCommand(followerId, userId));
+                return Ok(new { message = "User unfollowed successfully" });
+            }
+            catch (ValidationException ex)
+            {
+                var errors = ex.Errors.Select(error => new
+                {
+                    field = error.PropertyName,
+                    message = error.ErrorMessage
+                });
+                return BadRequest(new { errors });
+            }
+            catch (UserNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+        }
     }
 }

--- a/Community/Events/FollowCreatedEvent.cs
+++ b/Community/Events/FollowCreatedEvent.cs
@@ -1,0 +1,5 @@
+using BreastCancer.Community.Domain;
+
+namespace BreastCancer.Community.Events;
+
+public sealed record FollowCreatedEvent(string FollowerId, string FollowingId) : DomainEvent;

--- a/Community/Events/FollowCreatedEventHandler.cs
+++ b/Community/Events/FollowCreatedEventHandler.cs
@@ -1,0 +1,16 @@
+using MediatR;
+
+namespace BreastCancer.Community.Events;
+
+public sealed class FollowCreatedEventHandler : INotificationHandler<FollowCreatedEvent>
+{
+    private readonly IFollowCreatedEventSink _sink;
+
+    public FollowCreatedEventHandler(IFollowCreatedEventSink sink)
+    {
+        _sink = sink;
+    }
+
+    public Task Handle(FollowCreatedEvent notification, CancellationToken cancellationToken)
+        => _sink.RecordAsync(notification, cancellationToken);
+}

--- a/Community/Events/IFollowCreatedEventSink.cs
+++ b/Community/Events/IFollowCreatedEventSink.cs
@@ -1,0 +1,11 @@
+namespace BreastCancer.Community.Events;
+
+public interface IFollowCreatedEventSink
+{
+    Task RecordAsync(FollowCreatedEvent domainEvent, CancellationToken cancellationToken);
+}
+
+public sealed class NoOpFollowCreatedEventSink : IFollowCreatedEventSink
+{
+    public Task RecordAsync(FollowCreatedEvent domainEvent, CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/Community/Exceptions/AlreadyFollowingException.cs
+++ b/Community/Exceptions/AlreadyFollowingException.cs
@@ -1,0 +1,16 @@
+﻿using System.Runtime.Serialization;
+
+namespace BreastCancer.Community.Exceptions
+{
+    [Serializable]
+    public sealed class AlreadyFollowingException : Exception
+    {
+        public AlreadyFollowingException(string message) : base(message)
+        {
+        }
+
+        private AlreadyFollowingException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Community/Exceptions/UserNotFoundException.cs
+++ b/Community/Exceptions/UserNotFoundException.cs
@@ -1,0 +1,16 @@
+﻿using System.Runtime.Serialization;
+
+namespace BreastCancer.Community.Exceptions
+{
+    [Serializable]
+    public sealed class UserNotFoundException : Exception
+    {
+        public UserNotFoundException(string message) : base(message)
+        {
+        }
+        
+        private UserNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Community/Features/FollowUserCommand.cs
+++ b/Community/Features/FollowUserCommand.cs
@@ -1,0 +1,6 @@
+﻿using MediatR;
+
+namespace BreastCancer.Community.Features
+{
+    public sealed record FollowUserCommand(string FollowerId, string FollowingId) : IRequest<Unit>;
+}

--- a/Community/Features/FollowUserCommandHandler.cs
+++ b/Community/Features/FollowUserCommandHandler.cs
@@ -1,0 +1,62 @@
+﻿using BreastCancer.Community.Events;
+using BreastCancer.Community.Exceptions;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
+using MediatR;
+
+namespace BreastCancer.Community.Features
+{
+    public sealed class FollowUserCommandHandler : IRequestHandler<FollowUserCommand, Unit>
+    {
+        private readonly IPublisher _publisher;
+        private readonly IUnitOfWork _unitOfWork;
+
+        public FollowUserCommandHandler(IPublisher publisher, IUnitOfWork unitOfWork)
+        {
+            _publisher = publisher;
+            _unitOfWork = unitOfWork;
+        }
+
+
+        public async Task<Unit> Handle(FollowUserCommand request, CancellationToken cancellationToken)
+        {
+            await using var transaction = await _unitOfWork.BeginTransactionAsync();
+            var committed = false;
+            try
+            {
+                // TODO: validate that both users exist
+                var existing = await _unitOfWork.FollowRepository.FilterAsync(follow =>
+                    follow.FollowerId == request.FollowerId && follow.FollowingId == request.FollowingId);
+
+                if (existing.Any())
+                {
+                    throw new AlreadyFollowingException("You are already following this user.");
+                }
+
+                Follow follow = new Follow
+                {
+                    FollowerId = request.FollowerId,
+                    FollowingId = request.FollowingId
+                };
+
+                await _unitOfWork.FollowRepository.AddAsync(follow);
+                await _unitOfWork.SaveAsync();
+
+                await transaction.CommitAsync();
+                committed = true;
+            }
+            catch
+            {
+                if (!committed)
+                {
+                    await transaction.RollbackAsync();
+                }
+                throw;
+            }
+
+            await _publisher.Publish(new FollowCreatedEvent(request.FollowerId, request.FollowingId), cancellationToken);
+
+            return Unit.Value;
+        }
+    }
+}

--- a/Community/Features/FollowUserCommandValidator.cs
+++ b/Community/Features/FollowUserCommandValidator.cs
@@ -1,0 +1,21 @@
+﻿using FluentValidation;
+
+namespace BreastCancer.Community.Features
+{
+    public sealed class FollowUserCommandValidator : AbstractValidator<FollowUserCommand>
+    {
+        public FollowUserCommandValidator() 
+        { 
+            RuleFor(command => command.FollowerId)
+                .NotEmpty()
+                .WithMessage("FollowerId is required.");
+
+            RuleFor(command => command.FollowingId)
+                .NotEmpty()
+                .WithMessage("FolloweeId is required.")
+                .NotEqual(command => command.FollowerId)
+                .WithMessage("FollowerId and FolloweeId cannot be the same.");
+        }
+
+    }
+}

--- a/Community/Features/UnfollowUserCommand.cs
+++ b/Community/Features/UnfollowUserCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace BreastCancer.Community.Features;
+
+public sealed record UnfollowUserCommand(string FollowerId, string FollowingId) : IRequest<Unit>;

--- a/Community/Features/UnfollowUserCommandHandler.cs
+++ b/Community/Features/UnfollowUserCommandHandler.cs
@@ -1,0 +1,50 @@
+using BreastCancer.Community.Exceptions;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
+using MediatR;
+
+namespace BreastCancer.Community.Features;
+
+public sealed class UnfollowUserCommandHandler : IRequestHandler<UnfollowUserCommand, Unit>
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UnfollowUserCommandHandler(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Unit> Handle(UnfollowUserCommand request, CancellationToken cancellationToken)
+    {
+        await using var transaction = await _unitOfWork.BeginTransactionAsync();
+        var committed = false;
+        try
+        {
+            // TODO: validate that both users exist
+            var matches = await _unitOfWork.FollowRepository.FilterAsync(follow =>
+                follow.FollowerId == request.FollowerId && follow.FollowingId == request.FollowingId);
+
+            var follow = matches.FirstOrDefault();
+            if (follow == null)
+            {
+                throw new UserNotFoundException("Follow relationship not found.");
+            }
+
+            _unitOfWork.FollowRepository.Delete(follow);
+            await _unitOfWork.SaveAsync();
+
+            await transaction.CommitAsync();
+            committed = true;
+        }
+        catch
+        {
+            if (!committed)
+            {
+                await transaction.RollbackAsync();
+            }
+            throw;
+        }
+
+        return Unit.Value;
+    }
+}

--- a/Community/Features/UnfollowUserCommandValidator.cs
+++ b/Community/Features/UnfollowUserCommandValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace BreastCancer.Community.Features;
+
+public sealed class UnfollowUserCommandValidator : AbstractValidator<UnfollowUserCommand>
+{
+    public UnfollowUserCommandValidator()
+    {
+        RuleFor(command => command.FollowerId)
+            .NotEmpty()
+            .WithMessage("FollowerId is required.");
+
+        RuleFor(command => command.FollowingId)
+            .NotEmpty()
+            .WithMessage("FolloweeId is required.")
+            .NotEqual(command => command.FollowerId)
+            .WithMessage("FollowerId and FolloweeId cannot be the same.");
+    }
+}

--- a/Repository/Interface/IFollowRepository.cs
+++ b/Repository/Interface/IFollowRepository.cs
@@ -1,0 +1,8 @@
+﻿using BreastCancer.Models;
+
+namespace BreastCancer.Repository.Interface
+{
+    public interface IFollowRepository : IGenericRepository<Follow>
+    {
+    }
+}

--- a/Repository/Interface/IUnitOfWork.cs
+++ b/Repository/Interface/IUnitOfWork.cs
@@ -13,6 +13,8 @@ namespace BreastCancer.Repository.Interface
         IPatientDiagnosisRepository PatientDiagnosisRepository { get; }
         IPostRepository PostRepository { get; }
 
+        IFollowRepository FollowRepository { get; }
+
         Task<IDbContextTransaction> BeginTransactionAsync();
 
         Task<int> SaveAsync();

--- a/Repository/Repositories/FollowRepository.cs
+++ b/Repository/Repositories/FollowRepository.cs
@@ -1,0 +1,13 @@
+﻿using BreastCancer.Context;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
+
+namespace BreastCancer.Repository.Repositories
+{
+    public class FollowRepository : GenericRepository<Follow>, IFollowRepository
+    {
+        public FollowRepository(BreastCancerDB _Context) : base(_Context)
+        {
+        }
+    }
+}

--- a/Repository/Repositories/UnitOfWork.cs
+++ b/Repository/Repositories/UnitOfWork.cs
@@ -17,6 +17,7 @@ namespace BreastCancer.Repository.Repositories
         private IRefreshTokenRepository _refreshTokenRepository;
         private IPatientDiagnosisRepository _patientDiagnosisRepository;
         private IPostRepository _postRepository;
+        private IFollowRepository _followRepository;
 
         public UnitOfWork(BreastCancerDB Context)
         {
@@ -102,6 +103,18 @@ namespace BreastCancer.Repository.Repositories
                     _postRepository = new PostRepository(context);
                 }
                 return _postRepository;
+            }
+        }
+
+        public IFollowRepository FollowRepository
+        {
+            get
+            {
+                if (_followRepository == null)
+                {
+                    _followRepository = new FollowRepository(context);
+                }
+                return _followRepository;
             }
         }
 


### PR DESCRIPTION
Resolves #99

# Overview
This PR implements the core authenticated follow and unfollow capabilities for the Community module. It establishes the transactional handlers, domain events, validation constraints (including self-follow prevention), and exposes the POST/DELETE endpoints.

# Key Changes
* **Controller Endpoints:** Added `POST /community/users/{userId}/follow` and `DELETE /community/users/{userId}/follow` endpoints that extract the caller's identity via auth claims.
* **Transactional Reliability:** Handlers utilize database transactions (`BeginTransactionAsync` / `CommitAsync`) with explicit rollback safety, ensuring `FollowCreatedEvent` is only published via MediatR *after* a successful database commit.
* **Validation & Domain Logic:** Implemented `FollowUserCommandValidator` and `UnfollowUserCommandValidator` to reject empty inputs and prevent self-following (returning a 400 Bad Request).
* **Error Handling:** Added `AlreadyFollowingException` (maps to 409 Conflict) and utilizes `UserNotFoundException` (maps to 404 Not Found) for a robust API contract.
* **Architecture Extensibility:** Introduced the `IFollowCreatedEventSink` abstraction along with a `NoOpFollowCreatedEventSink` implementation registered in the `CommunityModule`.

# Deferred Items
Per project instructions, the following acceptance criteria are skipped in this PR and deferred to separate, dedicated tickets:
1. Integration with `IProfileService.UserExistsAsync` for cross-module user existence verification.
2. The 50 follow actions per hour rate-limiting restriction.

# Testing
* **FollowUserCommandHandlerTests:** Validates that duplicate follows safely throw, and valid follow records persist and publish events correctly.
* **UnfollowUserCommandHandlerTests:** Verifies that missing follow entries throw 404 errors and existing configurations are correctly removed.