### PR TITLE
feat: implement role-based visibility filtering in community feed

### DIFF
--- a/BreastCancer.Tests/Integration/FeedQueryHandlerTests.cs
+++ b/BreastCancer.Tests/Integration/FeedQueryHandlerTests.cs
@@ -42,6 +42,13 @@ public sealed class FeedQueryHandlerTests
         await using var dbContext = new BreastCancerDB(options);
         var loggerMock = new Mock<ILogger<GetFeedQueryHandler>>();
 
+        dbContext.Posts.AddRange(
+            new Post { Id = 6, AuthorId = "author-1", Content = "p6", CreatedAt = DateTime.UtcNow },
+            new Post { Id = 5, AuthorId = "author-1", Content = "p5", CreatedAt = DateTime.UtcNow.AddMinutes(-1) },
+            new Post { Id = 4, AuthorId = "author-1", Content = "p4", CreatedAt = DateTime.UtcNow.AddMinutes(-2) },
+            new Post { Id = 3, AuthorId = "author-1", Content = "p3", CreatedAt = DateTime.UtcNow.AddMinutes(-3) });
+        await dbContext.SaveChangesAsync();
+
         var handler = new GetFeedQueryHandler(multiplexerMock.Object, dbContext, loggerMock.Object);
 
         var result = await handler.Handle(new GetFeedQuery("user-1", null, 3), CancellationToken.None);
@@ -132,6 +139,11 @@ public sealed class FeedQueryHandlerTests
         await using var dbContext = new BreastCancerDB(options);
         var loggerMock = new Mock<ILogger<GetFeedQueryHandler>>();
 
+        dbContext.Posts.AddRange(
+            new Post { Id = 2, AuthorId = "author-1", Content = "p2", CreatedAt = DateTime.UtcNow },
+            new Post { Id = 1, AuthorId = "author-1", Content = "p1", CreatedAt = DateTime.UtcNow.AddMinutes(-1) });
+        await dbContext.SaveChangesAsync();
+
         var handler = new GetFeedQueryHandler(multiplexerMock.Object, dbContext, loggerMock.Object);
 
         var result = await handler.Handle(new GetFeedQuery("user-1", 3, 2), CancellationToken.None);
@@ -169,6 +181,12 @@ public sealed class FeedQueryHandlerTests
 
         await using var dbContext = new BreastCancerDB(options);
         var loggerMock = new Mock<ILogger<GetFeedQueryHandler>>();
+
+        dbContext.Posts.AddRange(
+            new Post { Id = 5, AuthorId = "author-1", Content = "p5", CreatedAt = DateTime.UtcNow },
+            new Post { Id = 4, AuthorId = "author-1", Content = "p4", CreatedAt = DateTime.UtcNow.AddMinutes(-1) },
+            new Post { Id = 3, AuthorId = "author-1", Content = "p3", CreatedAt = DateTime.UtcNow.AddMinutes(-2) });
+        await dbContext.SaveChangesAsync();
 
         var handler = new GetFeedQueryHandler(multiplexerMock.Object, dbContext, loggerMock.Object);
 

--- a/BreastCancer.Tests/Integration/FeedVisibilityTests.cs
+++ b/BreastCancer.Tests/Integration/FeedVisibilityTests.cs
@@ -74,4 +74,50 @@ public sealed class FeedVisibilityTests
         var contains = result.PostIds.Contains(1);
         contains.Should().Be(expectedVisible);
     }
+
+    [Theory]
+    [MemberData(nameof(VisibilityMatrix))]
+    public async Task FeedVisibility_AppliesFiltering_WhenRedisHit(string[] roles, PostVisibility visibility, bool expectedVisible)
+    {
+        var redisDbMock = new Mock<IDatabase>();
+        redisDbMock
+            .Setup(db => db.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+
+        redisDbMock
+            .Setup(db => db.SortedSetRangeByRankAsync(
+                It.IsAny<RedisKey>(),
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                Order.Descending,
+                It.IsAny<CommandFlags>()))
+            .ReturnsAsync(new RedisValue[] { "1" });
+
+        var multiplexerMock = new Mock<IConnectionMultiplexer>();
+        multiplexerMock
+            .Setup(m => m.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
+            .Returns(redisDbMock.Object);
+
+        var options = new DbContextOptionsBuilder<BreastCancerDB>()
+            .UseInMemoryDatabase($"feed-visibility-redis-{Guid.NewGuid()}")
+            .Options;
+
+        await using var dbContext = new BreastCancerDB(options);
+        var loggerMock = new Mock<ILogger<GetFeedQueryHandler>>();
+
+        var userId = "user-1";
+        var authorId = "author-1";
+
+        dbContext.Posts.Add(new Post { Id = 1, AuthorId = authorId, Content = "x", Visibility = visibility, CreatedAt = DateTime.UtcNow });
+
+        await dbContext.SaveChangesAsync();
+
+        var handler = new GetFeedQueryHandler(multiplexerMock.Object, dbContext, loggerMock.Object);
+
+        var query = new GetFeedQuery(userId, null, 10, roles);
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        var contains = result.PostIds.Contains(1);
+        contains.Should().Be(expectedVisible);
+    }
 }

--- a/BreastCancer.Tests/Integration/FeedVisibilityTests.cs
+++ b/BreastCancer.Tests/Integration/FeedVisibilityTests.cs
@@ -1,0 +1,77 @@
+using BreastCancer.Community.DTO.response;
+using BreastCancer.Community.Features.Feed;
+using BreastCancer.Context;
+using BreastCancer.Enum;
+using BreastCancer.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using StackExchange.Redis;
+using Xunit;
+
+namespace BreastCancer.Tests.Integration;
+
+public sealed class FeedVisibilityTests
+{
+    public static IEnumerable<object[]> VisibilityMatrix()
+    {
+        // role, visibility, expectedVisible
+        yield return new object[] { new[] { "Patient" }, PostVisibility.Public, true };
+        yield return new object[] { new[] { "Doctor" }, PostVisibility.Public, true };
+        yield return new object[] { new[] { "Caregiver" }, PostVisibility.Public, true };
+
+        yield return new object[] { new[] { "Patient" }, PostVisibility.PatientsOnly, true };
+        yield return new object[] { new[] { "Doctor" }, PostVisibility.PatientsOnly, true };
+        yield return new object[] { new[] { "Caregiver" }, PostVisibility.PatientsOnly, false };
+
+        yield return new object[] { new[] { "Doctor" }, PostVisibility.DoctorOnly, true };
+        yield return new object[] { new[] { "Patient" }, PostVisibility.DoctorOnly, false };
+        yield return new object[] { new[] { "Caregiver" }, PostVisibility.DoctorOnly, false };
+
+        yield return new object[] { new[] { "Caregiver" }, PostVisibility.CaregiverOnly, true };
+        yield return new object[] { new[] { "Doctor" }, PostVisibility.CaregiverOnly, true };
+        yield return new object[] { new[] { "Patient" }, PostVisibility.CaregiverOnly, false };
+
+    }
+
+    [Theory]
+    [MemberData(nameof(VisibilityMatrix))]
+    public async Task FeedVisibility_AppliesFiltering(string[] roles, PostVisibility visibility, bool expectedVisible)
+    {
+        var redisDbMock = new Mock<IDatabase>();
+        redisDbMock
+            .Setup(db => db.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(false);
+
+        var multiplexerMock = new Mock<IConnectionMultiplexer>();
+        multiplexerMock
+            .Setup(m => m.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
+            .Returns(redisDbMock.Object);
+
+        var options = new DbContextOptionsBuilder<BreastCancerDB>()
+            .UseInMemoryDatabase($"feed-visibility-{Guid.NewGuid()}")
+            .Options;
+
+        await using var dbContext = new BreastCancerDB(options);
+        var loggerMock = new Mock<ILogger<GetFeedQueryHandler>>();
+
+        var userId = "user-1";
+        var authorId = "author-1";
+
+        // Ensure the feed includes the author's posts via follow
+        dbContext.Follows.Add(new Follow { FollowerId = userId, FollowingId = authorId });
+
+        dbContext.Posts.Add(new Post { Id = 1, AuthorId = authorId, Content = "x", Visibility = visibility, CreatedAt = DateTime.UtcNow });
+
+        await dbContext.SaveChangesAsync();
+
+        var handler = new GetFeedQueryHandler(multiplexerMock.Object, dbContext, loggerMock.Object);
+
+        var query = new GetFeedQuery(userId, null, 10, roles);
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        var contains = result.PostIds.Contains(1);
+        contains.Should().Be(expectedVisible);
+    }
+}

--- a/Community/Controllers/CommunityController.cs
+++ b/Community/Controllers/CommunityController.cs
@@ -148,6 +148,8 @@ namespace BreastCancer.Community.Controllers
                 return Unauthorized(new { message = "Could not identify user" });
             }
 
+            var roles = User.GetRoles();
+
             var effectiveLimit = limit ?? 20;
             if (effectiveLimit > 50)
             {
@@ -158,7 +160,7 @@ namespace BreastCancer.Community.Controllers
                 effectiveLimit = 1;
             }
 
-            var feed = await mediator.Send(new GetFeedQuery(userId, cursor, effectiveLimit), cancellationToken);
+            var feed = await mediator.Send(new GetFeedQuery(userId, cursor, effectiveLimit, roles), cancellationToken);
             return Ok(feed);
         }
     }

--- a/Community/Features/Feed/GetFeedQuery.cs
+++ b/Community/Features/Feed/GetFeedQuery.cs
@@ -3,4 +3,4 @@ using MediatR;
 
 namespace BreastCancer.Community.Features.Feed;
 
-public sealed record GetFeedQuery(string UserId, int? Cursor, int Limit) : IRequest<FeedResponseDto>;
+public sealed record GetFeedQuery(string UserId, int? Cursor, int Limit, IReadOnlyCollection<string>? Roles = null) : IRequest<FeedResponseDto>;

--- a/Community/Features/Feed/GetFeedQueryHandler.cs
+++ b/Community/Features/Feed/GetFeedQueryHandler.cs
@@ -54,7 +54,6 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
     {
         var batchSize = normalizedLimit + 1;
         var visibleOrdered = new List<int>();
-        int? scannedLastId = null;
         var start = await GetRedisStartRankAsync(redisDb, feedKey, request.Cursor);
         var exhausted = false;
 
@@ -68,7 +67,6 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
             }
 
             var idsOrdered = batch.Select(v => (int)v).ToList();
-            scannedLastId = idsOrdered[^1];
 
             var posts = await _dbContext.Posts.AsNoTracking()
                 .Where(p => idsOrdered.Contains(p.Id) && !p.IsDeleted)
@@ -103,17 +101,7 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
             start += batch.Length;
         }
 
-        var response = BuildResponse(visibleOrdered, normalizedLimit);
-        if (response.PostIds.Count == 0 && !exhausted && scannedLastId.HasValue)
-        {
-            response = new FeedResponseDto
-            {
-                PostIds = response.PostIds,
-                NextCursor = scannedLastId.Value
-            };
-        }
-
-        return response;
+        return BuildResponse(visibleOrdered, normalizedLimit);
     }
 
     private async Task<FeedResponseDto> GetSqlFeedAsync(

--- a/Community/Features/Feed/GetFeedQueryHandler.cs
+++ b/Community/Features/Feed/GetFeedQueryHandler.cs
@@ -41,7 +41,8 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         }
 
         _logger.LogInformation("Feed cache miss for user {UserId}; falling back to SQL feed query.", request.UserId);
-        return await GetSqlFeedAsync(request, allowedVisibilities.ToArray(), normalizedLimit, cancellationToken);
+        var allowedVisibilityValues = allowedVisibilities.Select(v => (int)v).ToArray();
+        return await GetSqlFeedAsync(request, allowedVisibilityValues, normalizedLimit, cancellationToken);
     }
 
     private async Task<FeedResponseDto> GetRedisFeedAsync(
@@ -118,7 +119,7 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
 
     private async Task<FeedResponseDto> GetSqlFeedAsync(
         GetFeedQuery request,
-        PostVisibility[] allowedVisibilities,
+        int[] allowedVisibilityValues,
         int normalizedLimit,
         CancellationToken cancellationToken)
     {
@@ -146,14 +147,17 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         }
 
         var rawPosts = await query
-            .Where(p => allowedVisibilities.Contains(p.Visibility))
             .OrderByDescending(p => p.CreatedAt)
             .ThenByDescending(p => p.Id)
-            .Take(normalizedLimit + 1)
-            .Select(p => p.Id)
+            .Select(p => new { p.Id, p.Visibility })
             .ToListAsync(cancellationToken);
 
-        return BuildResponse(rawPosts, normalizedLimit);
+        var visibleOrdered = rawPosts
+            .Where(p => allowedVisibilityValues.Contains((int)p.Visibility))
+            .Select(p => p.Id)
+            .ToList();
+
+        return BuildResponse(visibleOrdered, normalizedLimit);
     }
 
     private static FeedResponseDto BuildResponse(List<int> visibleOrdered, int normalizedLimit)

--- a/Community/Features/Feed/GetFeedQueryHandler.cs
+++ b/Community/Features/Feed/GetFeedQueryHandler.cs
@@ -30,57 +30,95 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
 
         var normalizedLimit = Math.Clamp(request.Limit, 1, 50);
         var roleFlags = RoleFlags.Create(request.Roles);
+        var allowedVisibilities = GetAllowedVisibilities(roleFlags);
         var redisDb = _connectionMultiplexer.GetDatabase();
         var feedKey = BuildFeedKey(request.UserId);
 
         if (await redisDb.KeyExistsAsync(feedKey))
         {
             _logger.LogInformation("Feed cache hit for user {UserId}; retrieving feed from Redis.", request.UserId);
-            return await GetRedisFeedAsync(request, roleFlags, normalizedLimit, redisDb, feedKey, cancellationToken);
+            return await GetRedisFeedAsync(request, allowedVisibilities, normalizedLimit, redisDb, feedKey, cancellationToken);
         }
 
         _logger.LogInformation("Feed cache miss for user {UserId}; falling back to SQL feed query.", request.UserId);
-        return await GetSqlFeedAsync(request, roleFlags, normalizedLimit, cancellationToken);
+        return await GetSqlFeedAsync(request, allowedVisibilities.ToArray(), normalizedLimit, cancellationToken);
     }
 
     private async Task<FeedResponseDto> GetRedisFeedAsync(
         GetFeedQuery request,
-        RoleFlags roleFlags,
+        IReadOnlySet<PostVisibility> allowedVisibilities,
         int normalizedLimit,
         IDatabase redisDb,
         string feedKey,
         CancellationToken cancellationToken)
     {
-        var range = await GetRedisRangeAsync(redisDb, feedKey, request.Cursor, normalizedLimit + 1);
-        var idsOrdered = range.Select(v => (int)v).ToList();
-
-        if (idsOrdered.Count == 0)
-        {
-            return new FeedResponseDto();
-        }
-
-        var posts = await _dbContext.Posts.AsNoTracking()
-            .Where(p => idsOrdered.Contains(p.Id) && !p.IsDeleted)
-            .Select(p => new { p.Id, p.Visibility })
-            .ToListAsync(cancellationToken);
-
-        var postsById = posts.ToDictionary(p => p.Id);
+        var batchSize = normalizedLimit + 1;
         var visibleOrdered = new List<int>();
-        foreach (var id in idsOrdered)
+        int? scannedLastId = null;
+        var start = await GetRedisStartRankAsync(redisDb, feedKey, request.Cursor);
+        var exhausted = false;
+
+        while (visibleOrdered.Count < normalizedLimit + 1)
         {
-            if (!postsById.TryGetValue(id, out var p)) continue;
-            if (IsVisible(p.Visibility, roleFlags))
+            var batch = await redisDb.SortedSetRangeByRankAsync(feedKey, start, start + batchSize - 1, Order.Descending);
+            if (batch.Length == 0)
             {
-                visibleOrdered.Add(id);
+                exhausted = true;
+                break;
             }
+
+            var idsOrdered = batch.Select(v => (int)v).ToList();
+            scannedLastId = idsOrdered[^1];
+
+            var posts = await _dbContext.Posts.AsNoTracking()
+                .Where(p => idsOrdered.Contains(p.Id) && !p.IsDeleted)
+                .Select(p => new { p.Id, p.Visibility })
+                .ToListAsync(cancellationToken);
+
+            var postsById = posts.ToDictionary(p => p.Id);
+            foreach (var id in idsOrdered)
+            {
+                if (visibleOrdered.Count >= normalizedLimit + 1)
+                {
+                    break;
+                }
+
+                if (!postsById.TryGetValue(id, out var p))
+                {
+                    continue;
+                }
+
+                if (allowedVisibilities.Contains(p.Visibility))
+                {
+                    visibleOrdered.Add(id);
+                }
+            }
+
+            if (batch.Length < batchSize)
+            {
+                exhausted = true;
+                break;
+            }
+
+            start += batch.Length;
         }
 
-        return BuildResponse(visibleOrdered, normalizedLimit);
+        var response = BuildResponse(visibleOrdered, normalizedLimit);
+        if (response.PostIds.Count == 0 && !exhausted && scannedLastId.HasValue)
+        {
+            response = new FeedResponseDto
+            {
+                PostIds = response.PostIds,
+                NextCursor = scannedLastId.Value
+            };
+        }
+
+        return response;
     }
 
     private async Task<FeedResponseDto> GetSqlFeedAsync(
         GetFeedQuery request,
-        RoleFlags roleFlags,
+        PostVisibility[] allowedVisibilities,
         int normalizedLimit,
         CancellationToken cancellationToken)
     {
@@ -108,18 +146,14 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         }
 
         var rawPosts = await query
+            .Where(p => allowedVisibilities.Contains(p.Visibility))
             .OrderByDescending(p => p.CreatedAt)
             .ThenByDescending(p => p.Id)
             .Take(normalizedLimit + 1)
-            .Select(p => new { p.Id, p.Visibility })
+            .Select(p => p.Id)
             .ToListAsync(cancellationToken);
 
-        var visibleOrdered = rawPosts
-            .Where(p => IsVisible(p.Visibility, roleFlags))
-            .Select(p => p.Id)
-            .ToList();
-
-        return BuildResponse(visibleOrdered, normalizedLimit);
+        return BuildResponse(rawPosts, normalizedLimit);
     }
 
     private static FeedResponseDto BuildResponse(List<int> visibleOrdered, int normalizedLimit)
@@ -134,16 +168,29 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         };
     }
 
-    private static bool IsVisible(PostVisibility visibility, RoleFlags roles)
+    private static IReadOnlySet<PostVisibility> GetAllowedVisibilities(RoleFlags roles)
     {
-        return visibility switch
+        var allowed = new HashSet<PostVisibility> { PostVisibility.Public };
+
+        if (roles.IsDoctor)
         {
-            PostVisibility.Public => true,
-            PostVisibility.PatientsOnly => roles.IsPatient || roles.IsDoctor,
-            PostVisibility.DoctorOnly => roles.IsDoctor,
-            PostVisibility.CaregiverOnly => roles.IsCaregiver || roles.IsDoctor,
-            _ => false
-        };
+            allowed.Add(PostVisibility.DoctorOnly);
+            allowed.Add(PostVisibility.PatientsOnly);
+            allowed.Add(PostVisibility.CaregiverOnly);
+            return allowed;
+        }
+
+        if (roles.IsPatient)
+        {
+            allowed.Add(PostVisibility.PatientsOnly);
+        }
+
+        if (roles.IsCaregiver)
+        {
+            allowed.Add(PostVisibility.CaregiverOnly);
+        }
+
+        return allowed;
     }
 
     private readonly record struct RoleFlags(bool IsDoctor, bool IsPatient, bool IsCaregiver)
@@ -158,22 +205,20 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         }
     }
 
-    private static async Task<RedisValue[]> GetRedisRangeAsync(IDatabase redisDb, string feedKey, int? cursor, int limit)
+    private static async Task<long> GetRedisStartRankAsync(IDatabase redisDb, string feedKey, int? cursor)
     {
         if (!cursor.HasValue)
         {
-            return await redisDb.SortedSetRangeByRankAsync(feedKey, 0, limit - 1, Order.Descending);
+            return 0;
         }
 
         var rank = await redisDb.SortedSetRankAsync(feedKey, cursor.Value.ToString(), Order.Descending);
         if (!rank.HasValue)
         {
-            return await redisDb.SortedSetRangeByRankAsync(feedKey, 0, limit - 1, Order.Descending);
+            return 0;
         }
 
-        var start = rank.Value + 1;
-        var stop = start + limit - 1;
-        return await redisDb.SortedSetRangeByRankAsync(feedKey, start, stop, Order.Descending);
+        return rank.Value + 1;
     }
 
     private static string BuildFeedKey(string userId) => $"{FeedKeyPrefix}{userId}";

--- a/Community/Features/Feed/GetFeedQueryHandler.cs
+++ b/Community/Features/Feed/GetFeedQueryHandler.cs
@@ -95,6 +95,18 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         };
     }
 
+    private readonly record struct RoleFlags(bool IsDoctor, bool IsPatient, bool IsCaregiver)
+    {
+        public static RoleFlags Create(IReadOnlyCollection<string>? roles)
+        {
+            roles ??= Array.Empty<string>();
+            return new RoleFlags(
+                roles.Any(r => string.Equals(r, "Doctor", StringComparison.OrdinalIgnoreCase)),
+                roles.Any(r => string.Equals(r, "Patient", StringComparison.OrdinalIgnoreCase)),
+                roles.Any(r => string.Equals(r, "Caregiver", StringComparison.OrdinalIgnoreCase)));
+        }
+    }
+
     private static async Task<RedisValue[]> GetRedisRangeAsync(IDatabase redisDb, string feedKey, int? cursor, int limit)
     {
         if (!cursor.HasValue)

--- a/Community/Features/Feed/GetFeedQueryHandler.cs
+++ b/Community/Features/Feed/GetFeedQueryHandler.cs
@@ -41,8 +41,7 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         }
 
         _logger.LogInformation("Feed cache miss for user {UserId}; falling back to SQL feed query.", request.UserId);
-        var allowedVisibilityValues = allowedVisibilities.Select(v => (int)v).ToArray();
-        return await GetSqlFeedAsync(request, allowedVisibilityValues, normalizedLimit, cancellationToken);
+        return await GetSqlFeedAsync(request, roleFlags, normalizedLimit, cancellationToken);
     }
 
     private async Task<FeedResponseDto> GetRedisFeedAsync(
@@ -119,7 +118,7 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
 
     private async Task<FeedResponseDto> GetSqlFeedAsync(
         GetFeedQuery request,
-        int[] allowedVisibilityValues,
+        RoleFlags roleFlags,
         int normalizedLimit,
         CancellationToken cancellationToken)
     {
@@ -147,17 +146,19 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         }
 
         var rawPosts = await query
+            .Where(p => p.Visibility == PostVisibility.Public
+                || (roleFlags.IsDoctor && (p.Visibility == PostVisibility.DoctorOnly
+                    || p.Visibility == PostVisibility.PatientsOnly
+                    || p.Visibility == PostVisibility.CaregiverOnly))
+                || (!roleFlags.IsDoctor && roleFlags.IsPatient && p.Visibility == PostVisibility.PatientsOnly)
+                || (!roleFlags.IsDoctor && roleFlags.IsCaregiver && p.Visibility == PostVisibility.CaregiverOnly))
             .OrderByDescending(p => p.CreatedAt)
             .ThenByDescending(p => p.Id)
-            .Select(p => new { p.Id, p.Visibility })
+            .Take(normalizedLimit + 1)
+            .Select(p => p.Id)
             .ToListAsync(cancellationToken);
 
-        var visibleOrdered = rawPosts
-            .Where(p => allowedVisibilityValues.Contains((int)p.Visibility))
-            .Select(p => p.Id)
-            .ToList();
-
-        return BuildResponse(visibleOrdered, normalizedLimit);
+        return BuildResponse(rawPosts, normalizedLimit);
     }
 
     private static FeedResponseDto BuildResponse(List<int> visibleOrdered, int normalizedLimit)

--- a/Community/Features/Feed/GetFeedQueryHandler.cs
+++ b/Community/Features/Feed/GetFeedQueryHandler.cs
@@ -1,8 +1,8 @@
 using BreastCancer.Community.DTO.response;
 using BreastCancer.Context;
+using BreastCancer.Enum;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 
 namespace BreastCancer.Community.Features.Feed;
@@ -29,29 +29,61 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         }
 
         var normalizedLimit = Math.Clamp(request.Limit, 1, 50);
+        var roleFlags = RoleFlags.Create(request.Roles);
         var redisDb = _connectionMultiplexer.GetDatabase();
         var feedKey = BuildFeedKey(request.UserId);
 
         if (await redisDb.KeyExistsAsync(feedKey))
         {
             _logger.LogInformation("Feed cache hit for user {UserId}; retrieving feed from Redis.", request.UserId);
-            
-            var range = await GetRedisRangeAsync(redisDb, feedKey, request.Cursor, normalizedLimit + 1);
-            var postIds = range
-                .Take(normalizedLimit)
-                .Select(value => (int)value)
-                .ToList();
-            var hasMore = range.Length > normalizedLimit;
-
-            return new FeedResponseDto
-            {
-                PostIds = postIds,
-                NextCursor = hasMore && postIds.Count > 0 ? postIds[^1] : null
-            };
+            return await GetRedisFeedAsync(request, roleFlags, normalizedLimit, redisDb, feedKey, cancellationToken);
         }
 
         _logger.LogInformation("Feed cache miss for user {UserId}; falling back to SQL feed query.", request.UserId);
+        return await GetSqlFeedAsync(request, roleFlags, normalizedLimit, cancellationToken);
+    }
 
+    private async Task<FeedResponseDto> GetRedisFeedAsync(
+        GetFeedQuery request,
+        RoleFlags roleFlags,
+        int normalizedLimit,
+        IDatabase redisDb,
+        string feedKey,
+        CancellationToken cancellationToken)
+    {
+        var range = await GetRedisRangeAsync(redisDb, feedKey, request.Cursor, normalizedLimit + 1);
+        var idsOrdered = range.Select(v => (int)v).ToList();
+
+        if (idsOrdered.Count == 0)
+        {
+            return new FeedResponseDto();
+        }
+
+        var posts = await _dbContext.Posts.AsNoTracking()
+            .Where(p => idsOrdered.Contains(p.Id) && !p.IsDeleted)
+            .Select(p => new { p.Id, p.Visibility })
+            .ToListAsync(cancellationToken);
+
+        var postsById = posts.ToDictionary(p => p.Id);
+        var visibleOrdered = new List<int>();
+        foreach (var id in idsOrdered)
+        {
+            if (!postsById.TryGetValue(id, out var p)) continue;
+            if (IsVisible(p.Visibility, roleFlags))
+            {
+                visibleOrdered.Add(id);
+            }
+        }
+
+        return BuildResponse(visibleOrdered, normalizedLimit);
+    }
+
+    private async Task<FeedResponseDto> GetSqlFeedAsync(
+        GetFeedQuery request,
+        RoleFlags roleFlags,
+        int normalizedLimit,
+        CancellationToken cancellationToken)
+    {
         var query = from follow in _dbContext.Follows.AsNoTracking()
                     join post in _dbContext.Posts.AsNoTracking() on follow.FollowingId equals post.AuthorId
                     where follow.FollowerId == request.UserId && !post.IsDeleted
@@ -75,23 +107,42 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
             }
         }
 
-        var posts = await query
+        var rawPosts = await query
             .OrderByDescending(p => p.CreatedAt)
             .ThenByDescending(p => p.Id)
             .Take(normalizedLimit + 1)
-            .Select(p => p.Id)
+            .Select(p => new { p.Id, p.Visibility })
             .ToListAsync(cancellationToken);
 
-        var hasMorePosts = posts.Count > normalizedLimit;
-        if (hasMorePosts)
-        {
-            posts = posts.Take(normalizedLimit).ToList();
-        }
+        var visibleOrdered = rawPosts
+            .Where(p => IsVisible(p.Visibility, roleFlags))
+            .Select(p => p.Id)
+            .ToList();
+
+        return BuildResponse(visibleOrdered, normalizedLimit);
+    }
+
+    private static FeedResponseDto BuildResponse(List<int> visibleOrdered, int normalizedLimit)
+    {
+        var visiblePage = visibleOrdered.Take(normalizedLimit).ToList();
+        var hasVisibleMore = visibleOrdered.Count > normalizedLimit;
 
         return new FeedResponseDto
         {
-            PostIds = posts,
-            NextCursor = hasMorePosts && posts.Count > 0 ? posts[^1] : null
+            PostIds = visiblePage,
+            NextCursor = hasVisibleMore && visiblePage.Count > 0 ? visiblePage[^1] : null
+        };
+    }
+
+    private static bool IsVisible(PostVisibility visibility, RoleFlags roles)
+    {
+        return visibility switch
+        {
+            PostVisibility.Public => true,
+            PostVisibility.PatientsOnly => roles.IsPatient || roles.IsDoctor,
+            PostVisibility.DoctorOnly => roles.IsDoctor,
+            PostVisibility.CaregiverOnly => roles.IsCaregiver || roles.IsDoctor,
+            _ => false
         };
     }
 


### PR DESCRIPTION
Closes: #109

**Overview**
This PR introduces role-based visibility filtering to the `GET /community/feed` pipeline. User roles are extracted contextually and passed down through MediatR, ensuring that strict server-side validation blocks forbidden content before any payload is returned to the client application.

**Acceptance Criteria Met:**
* Implemented visibility filtering downstream during feed compilation (post-hydration, pre-response)
* Enforced structural visibility matrix boundaries:
  * `PatientsOnly` -> Visible to Patients and Doctors (hidden from Caregivers and Public)
  * `DoctorOnly` -> Visible exclusively to Doctors
  * `CaregiverOnly` -> Visible to Caregivers and Doctors (hidden from Patients and Public)
  * `Public` -> Visible to all active user roles
* Silently drops unauthorized posts from the array payload with no error markers or gap indicators
* Validates rules comprehensively across both hot Redis reads and cold SQL query paths
* Preserves centralized server-side authority without counting on client-side client enforcement

**Technical Highlights & Production Hardening:**
* **Post-Filter Cursor Correction:** Re-engineered pagination assembly to establish the correct `NextCursor` value *after* the visibility trimming takes place, preventing broken pagination loops or truncated pages when multiple consecutive items are stripped out.
* **RoleFlags Evaluation Utility:** Created a dedicated `RoleFlags` helper to cleanly map collection roles onto structural visibility requirements, reducing structural branching overhead during iteration blocks.
* **Dual-Path Isolation:** Keeps the underlying shared Redis feed cache generic (`community:feed:{userId}` preserves all entries), applying role rules dynamically on retrieval. This allows multi-role households or varied user contexts to poll the same source cache reliably.

**Testing**
* Added full matrix integration test sweeps under `FeedVisibilityTests` to isolate and affirm every role × visibility permutation.
* Refactored existing data seed parameters to guarantee deterministic pagination indices across legacy feed tests.
* Validated local builds and confirmed compilation success across all integration suites.