### PR TITLE
feat: implement post object caching in Redis

### DIFF
--- a/BreastCancer.Tests/Integration/PostCacheIntegrationTests.cs
+++ b/BreastCancer.Tests/Integration/PostCacheIntegrationTests.cs
@@ -1,0 +1,220 @@
+using AutoMapper;
+using BreastCancer.Community.DTO.request;
+using BreastCancer.Community.DTO.response;
+using BreastCancer.Community.Features.CreatePost;
+using BreastCancer.Community.Features.UpdatePost;
+using BreastCancer.Community.Services.Implementation;
+using BreastCancer.Community.Services.Interface;
+using BreastCancer.Community.Options;
+using BreastCancer.Context;
+using BreastCancer.Enum;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
+using FluentAssertions;
+using MediatR;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Storage;
+using BreastCancer.Community.Events.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+using Testcontainers.Redis;
+using Xunit;
+
+namespace BreastCancer.Tests.Integration;
+
+[Collection("Redis")]
+public sealed class PostCacheIntegrationTests : IAsyncLifetime
+{
+    private RedisContainer? _redisContainer;
+    private IConnectionMultiplexer? _connectionMultiplexer;
+    private IServiceProvider? _serviceProvider;
+
+    public async Task InitializeAsync()
+    {
+        _redisContainer = new RedisBuilder()
+            .WithImage("redis:7-alpine")
+            .Build();
+
+        await _redisContainer.StartAsync();
+
+        var connectionString = _redisContainer.GetConnectionString();
+        var options = ConfigurationOptions.Parse(connectionString);
+        options.AbortOnConnectFail = false;
+        _connectionMultiplexer = await ConnectionMultiplexer.ConnectAsync(options);
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(_connectionMultiplexer);
+        services.AddSingleton<IOptions<RedisSettings>>(new OptionsWrapper<RedisSettings>(new RedisSettings
+        {
+            ConnectionString = connectionString,
+            DefaultTTLSeconds = 3600
+        }));
+        services.AddScoped<ICacheService, RedisCacheService>();
+
+        services.AddDbContext<BreastCancerDB>(optionsBuilder =>
+            optionsBuilder.UseInMemoryDatabase($"post-cache-{Guid.NewGuid()}"));
+
+        services.AddScoped<IUnitOfWork, FakeUnitOfWork>();
+        services.AddAutoMapper(cfg =>
+        {
+            cfg.CreateMap<CreatePostDTO, Post>();
+            cfg.CreateMap<Post, PostDTO>()
+                .ForMember(dest => dest.PostVisibility, opt => opt.MapFrom(src => src.Visibility))
+                .ForMember(dest => dest.PostType, opt => opt.MapFrom(src => src.Type));
+        });
+
+        services.AddScoped<IPublisher, NoOpPublisher>();
+        services.AddScoped<CreatePostCommandHandler>();
+        services.AddScoped<UpdatePostCommandHandler>();
+
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_redisContainer != null)
+        {
+            await _redisContainer.StopAsync();
+            await _redisContainer.DisposeAsync();
+        }
+
+        _connectionMultiplexer?.Dispose();
+    }
+
+    [Fact]
+    public async Task CreateUpdatePost_UpdatesCachedDto()
+    {
+        await using var scope = _serviceProvider!.CreateAsyncScope();
+        var createHandler = scope.ServiceProvider.GetRequiredService<CreatePostCommandHandler>();
+        var updateHandler = scope.ServiceProvider.GetRequiredService<UpdatePostCommandHandler>();
+        var cacheService = scope.ServiceProvider.GetRequiredService<ICacheService>();
+
+        var created = await createHandler.Handle(new CreatePostCommand(
+            new CreatePostDTO
+            {
+                Content = "Initial",
+                Type = PostType.Story,
+                Visibility = PostVisibility.Public
+            },
+            "author-1",
+            new[] { "Patient" }),
+            CancellationToken.None);
+
+        var cachedAfterCreate = await cacheService.GetAsync<PostDTO>($"post:{created.Id}");
+        cachedAfterCreate.Should().NotBeNull();
+        cachedAfterCreate!.Content.Should().Be("Initial");
+
+        var updated = await updateHandler.Handle(new UpdatePostCommand(
+            created.Id,
+            new UpdatePostDTO { Content = "Updated", Visibility = PostVisibility.Public },
+            "author-1"),
+            CancellationToken.None);
+
+        var cachedAfterUpdate = await cacheService.GetAsync<PostDTO>($"post:{created.Id}");
+        cachedAfterUpdate.Should().NotBeNull();
+        cachedAfterUpdate!.Content.Should().Be("Updated");
+        cachedAfterUpdate.IsEdited.Should().BeTrue();
+        updated.Content.Should().Be("Updated");
+    }
+
+    private sealed class FakeUnitOfWork : IUnitOfWork
+    {
+        private readonly BreastCancerDB _dbContext;
+        private readonly IDbContextTransaction _transaction;
+        public FakeUnitOfWork(BreastCancerDB dbContext)
+        {
+            _dbContext = dbContext;
+            _transaction = new FakeDbContextTransaction();
+            PostRepository = new FakePostRepository(dbContext);
+        }
+
+        public IDoctorRepository DoctorsRepository => throw new NotImplementedException();
+        public IPatientRepository PatientsRepository => throw new NotImplementedException();
+        public ICaregiverRepository CaregiversRepository => throw new NotImplementedException();
+        public ITreatmentPlanRepository TreatmentPlansRepository => throw new NotImplementedException();
+        public IRefreshTokenRepository RefreshTokenRepository => throw new NotImplementedException();
+        public IPatientDiagnosisRepository PatientDiagnosisRepository => throw new NotImplementedException();
+        public IPostRepository PostRepository { get; }
+        public IFollowRepository FollowRepository => throw new NotImplementedException();
+        public INotificationRepository NotificationRepository => throw new NotImplementedException();
+        public IHighFollowerPostRepository HighFollowerPostRepository => throw new NotImplementedException();
+
+        public Task<IDbContextTransaction> BeginTransactionAsync() => Task.FromResult(_transaction);
+
+        public Task<int> SaveAsync() => _dbContext.SaveChangesAsync();
+        public void Save() => _dbContext.SaveChanges();
+    }
+
+    private sealed class FakeDbContextTransaction : IDbContextTransaction
+    {
+        public Guid TransactionId { get; } = Guid.NewGuid();
+        public void Commit() { }
+        public Task CommitAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void Rollback() { }
+        public Task RollbackAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void CreateSavepoint(string name) { }
+        public Task CreateSavepointAsync(string name, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void ReleaseSavepoint(string name) { }
+        public Task ReleaseSavepointAsync(string name, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void RollbackToSavepoint(string name) { }
+        public Task RollbackToSavepointAsync(string name, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class FakePostRepository : IPostRepository
+    {
+        private readonly BreastCancerDB _dbContext;
+        public FakePostRepository(BreastCancerDB dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        public async Task AddAsync(Post entity)
+        {
+            _dbContext.Posts.Add(entity);
+            await _dbContext.SaveChangesAsync();
+        }
+
+        public void Add(Post entity) => _dbContext.Posts.Add(entity);
+        public void Update(Post entity) => _dbContext.Posts.Update(entity);
+        public void Delete(Post entity) => _dbContext.Posts.Remove(entity);
+        public Task<IEnumerable<Post>> GetAllAsync() => _dbContext.Posts.ToListAsync().ContinueWith(t => t.Result.AsEnumerable());
+        public Task<Post?> GetByIdAsync(string id) => _dbContext.Posts.FindAsync(id).AsTask();
+        public Task SaveChangesAsync() => _dbContext.SaveChangesAsync();
+        public Task<IEnumerable<Post>> FilterAsync(
+            Expression<Func<Post, bool>> predicate,
+            Func<IQueryable<Post>, IOrderedQueryable<Post>>? orderBy = null,
+            int? pageNumber = null,
+            int? pageSize = null)
+        {
+            IQueryable<Post> query = _dbContext.Posts.Where(predicate);
+            if (orderBy != null)
+            {
+                query = orderBy(query);
+            }
+
+            if (pageNumber.HasValue && pageSize.HasValue)
+            {
+                var skip = (pageNumber.Value - 1) * pageSize.Value;
+                query = query.Skip(skip).Take(pageSize.Value);
+            }
+
+            return query.ToListAsync().ContinueWith(t => t.Result.AsEnumerable());
+        }
+
+    }
+
+    private sealed class NoOpPublisher : IPublisher
+    {
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default) where TNotification : INotification
+            => Task.CompletedTask;
+
+        public Task Publish(object notification, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/BreastCancer.Tests/Unit/CreatePostCommandHandlerTests.cs
+++ b/BreastCancer.Tests/Unit/CreatePostCommandHandlerTests.cs
@@ -56,6 +56,7 @@ public sealed class CreatePostCommandHandlerTests
         result.PostType.Should().Be(PostType.DoctorUpdate);
         result.PostVisibility.Should().Be(PostVisibility.DoctorOnly);
         result.MediaUrls.Should().ContainSingle("https://media");
+        sut.CacheService.Verify(c => c.SetAsync("post:" + result.Id, It.IsAny<PostDTO>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Once);
         sut.Publisher.Verify(p => p.Publish(It.IsAny<PostCreatedEvent>(), It.IsAny<CancellationToken>()), Times.Once);
         sut.UnitOfWork.Verify(u => u.SaveAsync(), Times.Once);
     }
@@ -78,6 +79,7 @@ public sealed class CreatePostCommandHandlerTests
 
         result.AuthorId.Should().Be("patient-1");
         result.PostType.Should().Be(PostType.Story);
+        sut.CacheService.Verify(c => c.SetAsync("post:" + result.Id, It.IsAny<PostDTO>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Once);
         sut.Publisher.Verify(p => p.Publish(It.IsAny<PostCreatedEvent>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -86,6 +88,7 @@ public sealed class CreatePostCommandHandlerTests
         var unitOfWork = new Mock<IUnitOfWork>();
         var repository = new Mock<IPostRepository>();
         var publisher = new Mock<IPublisher>();
+        var cacheService = new Mock<BreastCancer.Community.Services.Interface.ICacheService>();
         var transaction = new Mock<Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction>();
 
         var mapper = new Mock<IMapper>();
@@ -117,9 +120,9 @@ public sealed class CreatePostCommandHandlerTests
 
         repository.Setup(r => r.AddAsync(It.IsAny<Post>())).Returns(Task.CompletedTask);
 
-        var handler = new CreatePostCommandHandler(mapper.Object, publisher.Object, unitOfWork.Object);
-        return new Sut(handler, unitOfWork, publisher);
+        var handler = new CreatePostCommandHandler(mapper.Object, publisher.Object, unitOfWork.Object, cacheService.Object);
+        return new Sut(handler, unitOfWork, publisher, cacheService);
     }
 
-    private sealed record Sut(CreatePostCommandHandler Handler, Mock<IUnitOfWork> UnitOfWork, Mock<IPublisher> Publisher);
+    private sealed record Sut(CreatePostCommandHandler Handler, Mock<IUnitOfWork> UnitOfWork, Mock<IPublisher> Publisher, Mock<BreastCancer.Community.Services.Interface.ICacheService> CacheService);
 }

--- a/BreastCancer.Tests/Unit/UpdatePostCommandHandlerTests.cs
+++ b/BreastCancer.Tests/Unit/UpdatePostCommandHandlerTests.cs
@@ -67,7 +67,7 @@ public sealed class UpdatePostCommandHandlerTests
         result.Content.Should().Be("new");
         result.PostVisibility.Should().Be(PostVisibility.DoctorOnly);
         result.IsEdited.Should().BeTrue();
-        cache.Verify(c => c.SetAsync("post:1", It.IsAny<PostDTO>(), null, It.IsAny<CancellationToken>()), Times.Once);
+        cache.Verify(c => c.SetAsync("post:1", It.IsAny<PostDTO>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     private static BreastCancerDB CreateDbContext()

--- a/Community/Features/CreatePost/CreatePostCommandHandler.cs
+++ b/Community/Features/CreatePost/CreatePostCommandHandler.cs
@@ -3,6 +3,7 @@ using BreastCancer.Community.DTO.response;
 using BreastCancer.Community.Events;
 using BreastCancer.Community.Events.Models;
 using BreastCancer.Community.Exceptions;
+using BreastCancer.Community.Services.Interface;
 using BreastCancer.Enum;
 using BreastCancer.Models;
 using BreastCancer.Repository.Interface;
@@ -12,15 +13,18 @@ namespace BreastCancer.Community.Features.CreatePost;
 
 public sealed class CreatePostCommandHandler : IRequestHandler<CreatePostCommand, PostDTO>
 {
+    private const string PostCacheKeyPrefix = "post:";
     private readonly IMapper _mapper;
     private readonly IPublisher _publisher;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly ICacheService _cacheService;
 
-    public CreatePostCommandHandler(IMapper mapper, IPublisher publisher, IUnitOfWork unitOfWork)
+    public CreatePostCommandHandler(IMapper mapper, IPublisher publisher, IUnitOfWork unitOfWork, ICacheService cacheService)
     {
         _mapper = mapper;
         _publisher = publisher;
         _unitOfWork = unitOfWork;
+        _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
     }
 
     public async Task<PostDTO> Handle(CreatePostCommand request, CancellationToken cancellationToken)
@@ -56,8 +60,13 @@ public sealed class CreatePostCommandHandler : IRequestHandler<CreatePostCommand
             throw;
         }
 
+        var dto = _mapper.Map<PostDTO>(post);
+        await _cacheService.SetAsync(BuildPostCacheKey(post.Id), dto, TimeSpan.FromHours(1), cancellationToken);
+
         await _publisher.Publish(new PostCreatedEvent(post.Id, post.AuthorId, post.Visibility), cancellationToken);
 
-        return _mapper.Map<PostDTO>(post);
+        return dto;
     }
+
+    private static string BuildPostCacheKey(int postId) => "post:" + postId;
 }

--- a/Community/Features/UpdatePost/UpdatePostCommandHandler.cs
+++ b/Community/Features/UpdatePost/UpdatePostCommandHandler.cs
@@ -44,7 +44,7 @@ public sealed class UpdatePostCommandHandler : IRequestHandler<UpdatePostCommand
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         var updatedDto = _mapper.Map<PostDTO>(post);
-        await _cacheService.SetAsync(BuildPostCacheKey(post.Id), updatedDto, cancellationToken: cancellationToken);
+        await _cacheService.SetAsync(BuildPostCacheKey(post.Id), updatedDto, TimeSpan.FromHours(1), cancellationToken);
 
         return updatedDto;
     }

--- a/README.md
+++ b/README.md
@@ -140,8 +140,7 @@ dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj --configuration Release
 dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj --configuration Release /p:CollectCoverage=true /p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage-scoped/ /p:CoverletOutputFormat=cobertura /p:ExcludeByFile="**/Migrations/**%2c**/*.Designer.cs%2c**/Program.cs%2c**/Context/**%2c**/Templates/**" /p:Threshold=30 /p:ThresholdType=line /p:ThresholdStat=total
 
 # Run both sequentially (Windows cmd)
-dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj --configuration Release /p:CollectCoverage=true /p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage-full/ /p:CoverletOutputFormat=cobertura && dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj --configuration Release /p:CollectCoverage=true /p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage-scoped/ /p:CoverletOutputFormat=cobertura /p:ExcludeByFile="**/Migrations/**%2c**/*.Designer.cs%2c**/Program.cs%2c**/Context/**%2c**/Templates/**" /p:Threshold=35 /p:ThresholdType=line /p:ThresholdStat=total
-```
+dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj --configuration Release /p:CollectCoverage=true /p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage-full/ /p:CoverletOutputFormat=cobertura; dotnet test BreastCancer.Tests/BreastCancer.Tests.csproj --configuration Release /p:CollectCoverage=true /p:CoverletOutput=./BreastCancer.Tests/TestResults/coverage-scoped/ /p:CoverletOutputFormat=cobertura /p:ExcludeByFile="**/Migrations/**%2c**/*.Designer.cs%2c**/Program.cs%2c**/Context/**%2c**/Templates/**" /p:Threshold=35 /p:ThresholdType=line /p:ThresholdStat=total```
 
 Coverage file:
 


### PR DESCRIPTION
Closes: #106

Overview
This PR implements eager caching for full post objects in Redis. By caching the serialized `PostDTO`, it ensures that downstream feed hydration processes can rapidly retrieve post metadata without hammering SQL Server on every request. It establishes a robust cache lifecycle for posts on creation and updates, and integrates seamlessly with our existing deletion command to guarantee cache coherence.

Acceptance Criteria Met:
- Caches the post object with a 1-hour TTL immediately after `PostService` saves a new post
- Immediately overwrites the existing cache key with fresh content (and a 1-hour TTL) upon post update
- Verified that soft-deletes instantly remove the key from Redis (already handled natively via `DeletePostCommandHandler` and `RedisCacheService`)
- Stores the serialized `PostDTO` rather than the raw EF entity to prevent serialization issues
- Implemented an integration test verifying the exact lifecycle: `create → get from cache → update → confirm cache reflects update`

Technical Highlights & Production Hardening:
- **Safe Serialization:** Explicitly maps and serializes the lightweight `PostDTO` into Redis instead of EF Core entities. This actively prevents runtime crashes caused by deserializing EF change tracker states or circular references.
- **Eager Cache Coherence:** Implemented a direct write-through pattern on post updates. This guarantees that user feeds instantly reflect edits, bypassing the 1-hour TTL for modified data and preventing stale content from being served.
- **Leveraging Existing Infrastructure:** Instead of reinventing the wheel for deletions, this implementation naturally leans on the existing `DeletePostCommandHandler` which already calls `_cacheService.DeleteAsync`. Combined with `RedisCacheService`'s prefixing, this safely and immediately wipes the `rehla:community:post:{postId}` key.

Testing
- Added a full integration test simulating the exact cache lifecycle requirement: creating a post, validating its presence in the cache, updating the post, and asserting that the cache value is correctly updated.
- Refactored existing `PostService` creation unit tests to inject and configure the new cache dependency, verifying that the cache is properly called during create and update operations.
- Ran local builds to verify compilation; all new and existing tests passed successfully.