### PR TITLE
feat: implement post hydration with cache-aside pattern

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -41,7 +41,7 @@ jobs:
           /p:CoverletOutput=./TestResults/coverage-scoped/
           /p:CoverletOutputFormat=cobertura
           /p:ExcludeByFile="**/Migrations/**%2c**/*.Designer.cs%2c**/Program.cs%2c**/Context/**%2c**/Templates/**"
-          /p:Threshold=40
+          /p:Threshold=45
           /p:ThresholdType=line
           /p:ThresholdStat=total
 

--- a/BreastCancer.Tests/Integration/CommunityControllerIntegrationTests.cs
+++ b/BreastCancer.Tests/Integration/CommunityControllerIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Collections.Generic;
+using System.Linq;
 using BreastCancer.Community.Controllers;
 using BreastCancer.Community.DTO.request;
 using BreastCancer.Community.DTO.response;
@@ -10,7 +11,6 @@ using BreastCancer.Community.Features.Feed;
 using BreastCancer.Community.Features.GetPost;
 using BreastCancer.Community.Features.UpdatePost;
 using BreastCancer.Enum;
-using MediatR;
 using FluentAssertions;
 using MediatR;
 using Microsoft.AspNetCore.Authentication;
@@ -40,7 +40,16 @@ public class CommunityControllerIntegrationTests
     public async Task GetFeed_ReturnsOk_WithFeedFromMediator()
     {
         var fake = new FakeMediator();
-        fake.Response = new FeedResponseDto { PostIds = new List<int> { 10, 20, 30 }, NextCursor = 30 };
+        fake.Response = new FeedResponseDto
+        {
+            Posts = new List<PostDTO>
+            {
+                new() { Id = 10 },
+                new() { Id = 20 },
+                new() { Id = 30 }
+            },
+            NextCursor = 30
+        };
 
         await using var app = await BuildAppAsync(fake);
         using var client = CreateAuthenticatedClient(app, "user-1");
@@ -50,7 +59,7 @@ public class CommunityControllerIntegrationTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var payload = await response.Content.ReadFromJsonAsync<FeedResponseDto>();
         payload.Should().NotBeNull();
-        payload!.PostIds.Should().ContainInOrder(new[] { 10, 20, 30 });
+        payload!.Posts.Select(p => p.Id).Should().ContainInOrder(new[] { 10, 20, 30 });
         payload.NextCursor.Should().Be(30);
     }
 
@@ -247,7 +256,16 @@ public class CommunityControllerIntegrationTests
         public GetPostQuery? LastGetPostQuery { get; private set; }
         public UpdatePostCommand? LastUpdatePostCommand { get; private set; }
         public DeletePostCommand? LastDeletePostCommand { get; private set; }
-        public FeedResponseDto Response { get; set; } = new FeedResponseDto { PostIds = new List<int> { 1, 2, 3 }, NextCursor = 3 };
+        public FeedResponseDto Response { get; set; } = new FeedResponseDto
+        {
+            Posts = new List<PostDTO>
+            {
+                new() { Id = 1 },
+                new() { Id = 2 },
+                new() { Id = 3 }
+            },
+            NextCursor = 3
+        };
         public PostDTO GetPostResponse { get; set; } = new PostDTO
         {
             Id = 1,

--- a/BreastCancer.Tests/Integration/FeedQueryHandlerTests.cs
+++ b/BreastCancer.Tests/Integration/FeedQueryHandlerTests.cs
@@ -1,6 +1,8 @@
 using BreastCancer.Community.DTO.response;
 using BreastCancer.Community.Features.Feed;
+using BreastCancer.Community.Services.Interface;
 using BreastCancer.Context;
+using BreastCancer.Enum;
 using BreastCancer.Models;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -13,224 +15,126 @@ namespace BreastCancer.Tests.Integration;
 
 public sealed class FeedQueryHandlerTests
 {
+    private readonly Mock<IDatabase> _redisDbMock = new();
+    private readonly Mock<IConnectionMultiplexer> _multiplexerMock = new();
+    private readonly Mock<ICacheService> _cacheServiceMock = new();
+    private readonly Mock<ILogger<GetFeedQueryHandler>> _loggerMock = new();
+    private readonly DbContextOptions<BreastCancerDB> _dbOptions;
+
+    public FeedQueryHandlerTests()
+    {
+        _multiplexerMock.Setup(m => m.GetDatabase(It.IsAny<int>(), It.IsAny<object?>())).Returns(_redisDbMock.Object);
+        _dbOptions = new DbContextOptionsBuilder<BreastCancerDB>()
+            .UseInMemoryDatabase($"feed-test-{Guid.NewGuid()}")
+            .Options;
+    }
+
     [Fact]
     public async Task Handle_WhenRedisHasFeed_ReturnsPostIdsAndNextCursor()
     {
-        var redisDbMock = new Mock<IDatabase>();
-        redisDbMock
-            .Setup(db => db.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
-            .ReturnsAsync(true);
-
-        redisDbMock
-            .Setup(db => db.SortedSetRangeByRankAsync(
-                It.IsAny<RedisKey>(),
-                It.IsAny<long>(),
-                It.IsAny<long>(),
-                Order.Descending,
-                It.IsAny<CommandFlags>()))
+        _redisDbMock.Setup(db => db.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>())).ReturnsAsync(true);
+        _redisDbMock.Setup(db => db.SortedSetRangeByRankAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<long>(), Order.Descending, It.IsAny<CommandFlags>()))
             .ReturnsAsync(new RedisValue[] { "6", "5", "4", "3" });
 
-        var multiplexerMock = new Mock<IConnectionMultiplexer>();
-        multiplexerMock
-            .Setup(m => m.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
-            .Returns(redisDbMock.Object);
-
-        var options = new DbContextOptionsBuilder<BreastCancerDB>()
-            .UseInMemoryDatabase($"feed-test-{Guid.NewGuid()}")
-            .Options;
-
-        await using var dbContext = new BreastCancerDB(options);
-        var loggerMock = new Mock<ILogger<GetFeedQueryHandler>>();
-
+        await using var dbContext = new BreastCancerDB(_dbOptions);
         dbContext.Posts.AddRange(
-            new Post { Id = 6, AuthorId = "author-1", Content = "p6", CreatedAt = DateTime.UtcNow },
-            new Post { Id = 5, AuthorId = "author-1", Content = "p5", CreatedAt = DateTime.UtcNow.AddMinutes(-1) },
-            new Post { Id = 4, AuthorId = "author-1", Content = "p4", CreatedAt = DateTime.UtcNow.AddMinutes(-2) },
-            new Post { Id = 3, AuthorId = "author-1", Content = "p3", CreatedAt = DateTime.UtcNow.AddMinutes(-3) });
+            new Post { Id = 6, AuthorId = "author-1", Content = "Test post content", Visibility = PostVisibility.Public, CreatedAt = DateTime.UtcNow },
+            new Post { Id = 5, AuthorId = "author-1", Content = "Test post content", Visibility = PostVisibility.Public, CreatedAt = DateTime.UtcNow.AddMinutes(-1) },
+            new Post { Id = 4, AuthorId = "author-1", Content = "Test post content", Visibility = PostVisibility.Public, CreatedAt = DateTime.UtcNow.AddMinutes(-2) },
+            new Post { Id = 3, AuthorId = "author-1", Content = "Test post content", Visibility = PostVisibility.Public, CreatedAt = DateTime.UtcNow.AddMinutes(-3) });
         await dbContext.SaveChangesAsync();
 
-        var handler = new GetFeedQueryHandler(multiplexerMock.Object, dbContext, loggerMock.Object);
+        var handler = new GetFeedQueryHandler(_multiplexerMock.Object, dbContext, _cacheServiceMock.Object, _loggerMock.Object);
 
         var result = await handler.Handle(new GetFeedQuery("user-1", null, 3), CancellationToken.None);
 
-        result.PostIds.Should().Equal(new[] { 6, 5, 4 });
+        result.Posts.Select(p => p.Id).Should().Equal(new[] { 6, 5, 4 });
         result.NextCursor.Should().Be(4);
     }
 
     [Fact]
     public async Task Handle_WhenRedisMissing_FallsBackToSqlAndLogs()
     {
-        var redisDbMock = new Mock<IDatabase>();
-        redisDbMock
-            .Setup(db => db.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
-            .ReturnsAsync(false);
+        _redisDbMock.Setup(db => db.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>())).ReturnsAsync(false);
 
-        var multiplexerMock = new Mock<IConnectionMultiplexer>();
-        multiplexerMock
-            .Setup(m => m.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
-            .Returns(redisDbMock.Object);
-
-        var options = new DbContextOptionsBuilder<BreastCancerDB>()
-            .UseInMemoryDatabase($"feed-test-{Guid.NewGuid()}")
-            .Options;
-
-        await using var dbContext = new BreastCancerDB(options);
-        var loggerMock = new Mock<ILogger<GetFeedQueryHandler>>();
-
+        await using var dbContext = new BreastCancerDB(_dbOptions);
         var now = DateTime.UtcNow;
         dbContext.Follows.AddRange(
             new Follow { FollowerId = "user-1", FollowingId = "author-1" },
             new Follow { FollowerId = "user-1", FollowingId = "author-2" });
 
         dbContext.Posts.AddRange(
-            new Post { Id = 10, AuthorId = "author-1", Content = "p1", CreatedAt = now },
-            new Post { Id = 9, AuthorId = "author-2", Content = "p2", CreatedAt = now.AddMinutes(-1) },
-            new Post { Id = 8, AuthorId = "author-1", Content = "p3", CreatedAt = now.AddMinutes(-2) });
-
+            new Post { Id = 10, AuthorId = "author-1", Content = "Test post content", Visibility = PostVisibility.Public, CreatedAt = now },
+            new Post { Id = 9, AuthorId = "author-2", Content = "Test post content", Visibility = PostVisibility.Public, CreatedAt = now.AddMinutes(-1) },
+            new Post { Id = 8, AuthorId = "author-1", Content = "Test post content", Visibility = PostVisibility.Public, CreatedAt = now.AddMinutes(-2) });
         await dbContext.SaveChangesAsync();
 
-        var handler = new GetFeedQueryHandler(multiplexerMock.Object, dbContext, loggerMock.Object);
+        var handler = new GetFeedQueryHandler(_multiplexerMock.Object, dbContext, _cacheServiceMock.Object, _loggerMock.Object);
 
         var result = await handler.Handle(new GetFeedQuery("user-1", null, 2), CancellationToken.None);
 
-        result.PostIds.Should().Equal(new[] { 10, 9 });
+        result.Posts.Select(p => p.Id).Should().Equal(new[] { 10, 9 });
         result.NextCursor.Should().Be(9);
 
-        loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Information,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Feed cache miss")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
+        _loggerMock.Verify(x => x.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Feed cache miss")),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
     }
 
     [Fact]
-    public async Task Handle_WhenRedisHasCursor_StartsAfterCursor()
+    public async Task Handle_Hydration_With15CacheHitsAnd5Misses_BatchesSqlAndSetsCache()
     {
-        var redisDbMock = new Mock<IDatabase>();
-        redisDbMock
-            .Setup(db => db.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
-            .ReturnsAsync(true);
+        // Arrange
+        _redisDbMock.Setup(db => db.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>())).ReturnsAsync(true);
 
-        redisDbMock
-            .Setup(db => db.SortedSetRankAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), Order.Descending, It.IsAny<CommandFlags>()))
-            .ReturnsAsync(0L);
+        var feedIds = Enumerable.Range(1, 20).Select(id => (RedisValue)id.ToString()).ToArray();
+        _redisDbMock.Setup(db => db.SortedSetRangeByRankAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<long>(), Order.Descending, It.IsAny<CommandFlags>()))
+            .ReturnsAsync(feedIds);
 
-        redisDbMock
-            .Setup(db => db.SortedSetRangeByRankAsync(
-                It.IsAny<RedisKey>(),
-                It.IsAny<long>(),
-                It.IsAny<long>(),
-                Order.Descending,
-                It.IsAny<CommandFlags>()))
-            .ReturnsAsync(new RedisValue[] { "2", "1" });
+        // Setup Cache Hits for 1-15, Misses for 16-20
+        _cacheServiceMock.Setup(c => c.GetAsync<PostDTO>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string key, CancellationToken _) =>
+            {
+                var idStr = key.Split(':').Last();
+                if (int.TryParse(idStr, out int id) && id <= 15)
+                {
+                    return new PostDTO { Id = id, Content = "Cached", PostVisibility = PostVisibility.Public, AuthorId = "author-1" };
+                }
+                return null;
+            });
 
-        var multiplexerMock = new Mock<IConnectionMultiplexer>();
-        multiplexerMock
-            .Setup(m => m.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
-            .Returns(redisDbMock.Object);
+        var stringSetCallCount = 0;
+        _cacheServiceMock.Setup(c => c.SetAsync(It.IsAny<string>(), It.IsAny<PostDTO>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Callback(() => stringSetCallCount++) // Callback BEFORE Returns/ReturnsAsync guarantees execution
+            .Returns(Task.CompletedTask);
 
-        var options = new DbContextOptionsBuilder<BreastCancerDB>()
-            .UseInMemoryDatabase($"feed-test-{Guid.NewGuid()}")
-            .Options;
-
-        await using var dbContext = new BreastCancerDB(options);
-        var loggerMock = new Mock<ILogger<GetFeedQueryHandler>>();
-
-        dbContext.Posts.AddRange(
-            new Post { Id = 2, AuthorId = "author-1", Content = "p2", CreatedAt = DateTime.UtcNow },
-            new Post { Id = 1, AuthorId = "author-1", Content = "p1", CreatedAt = DateTime.UtcNow.AddMinutes(-1) });
+        await using var dbContext = new BreastCancerDB(_dbOptions);
+        for (int i = 1; i <= 20; i++)
+        {
+            dbContext.Posts.Add(new Post
+            {
+                Id = i,
+                AuthorId = "author-1",
+                Content = i <= 15 ? "Cached" : "FromDB",
+                Visibility = PostVisibility.Public,
+                IsDeleted = false
+            });
+        }
         await dbContext.SaveChangesAsync();
 
-        var handler = new GetFeedQueryHandler(multiplexerMock.Object, dbContext, loggerMock.Object);
+        var handler = new GetFeedQueryHandler(_multiplexerMock.Object, dbContext, _cacheServiceMock.Object, _loggerMock.Object);
 
-        var result = await handler.Handle(new GetFeedQuery("user-1", 3, 2), CancellationToken.None);
+        // Act
+        var result = await handler.Handle(new GetFeedQuery("user-1", null, 20), CancellationToken.None);
 
-        result.PostIds.Should().Equal(new[] { 2, 1 });
-        result.NextCursor.Should().BeNull();
-        redisDbMock.Verify(db => db.SortedSetRankAsync(It.IsAny<RedisKey>(), "3", Order.Descending, It.IsAny<CommandFlags>()), Times.Once);
-    }
+        // Assert
+        result.Posts.Should().HaveCount(20);
+        result.Posts.Count(p => p.Content == "Cached").Should().Be(15);
+        result.Posts.Count(p => p.Content == "FromDB").Should().Be(5);
 
-    [Fact]
-    public async Task Handle_WhenRedisHasMoreThanLimit_ReturnsNextCursor()
-    {
-        var redisDbMock = new Mock<IDatabase>();
-        redisDbMock
-            .Setup(db => db.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
-            .ReturnsAsync(true);
-
-        redisDbMock
-            .Setup(db => db.SortedSetRangeByRankAsync(
-                It.IsAny<RedisKey>(),
-                It.IsAny<long>(),
-                It.IsAny<long>(),
-                Order.Descending,
-                It.IsAny<CommandFlags>()))
-            .ReturnsAsync(new RedisValue[] { "5", "4", "3" });
-
-        var multiplexerMock = new Mock<IConnectionMultiplexer>();
-        multiplexerMock
-            .Setup(m => m.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
-            .Returns(redisDbMock.Object);
-
-        var options = new DbContextOptionsBuilder<BreastCancerDB>()
-            .UseInMemoryDatabase($"feed-test-{Guid.NewGuid()}")
-            .Options;
-
-        await using var dbContext = new BreastCancerDB(options);
-        var loggerMock = new Mock<ILogger<GetFeedQueryHandler>>();
-
-        dbContext.Posts.AddRange(
-            new Post { Id = 5, AuthorId = "author-1", Content = "p5", CreatedAt = DateTime.UtcNow },
-            new Post { Id = 4, AuthorId = "author-1", Content = "p4", CreatedAt = DateTime.UtcNow.AddMinutes(-1) },
-            new Post { Id = 3, AuthorId = "author-1", Content = "p3", CreatedAt = DateTime.UtcNow.AddMinutes(-2) });
-        await dbContext.SaveChangesAsync();
-
-        var handler = new GetFeedQueryHandler(multiplexerMock.Object, dbContext, loggerMock.Object);
-
-        var result = await handler.Handle(new GetFeedQuery("user-1", null, 2), CancellationToken.None);
-
-        result.PostIds.Should().Equal(new[] { 5, 4 });
-        result.NextCursor.Should().Be(4);
-    }
-
-    [Fact]
-    public async Task Handle_WhenSqlHasMoreThanLimit_ReturnsNextCursor()
-    {
-        var redisDbMock = new Mock<IDatabase>();
-        redisDbMock
-            .Setup(db => db.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
-            .ReturnsAsync(false);
-
-        var multiplexerMock = new Mock<IConnectionMultiplexer>();
-        multiplexerMock
-            .Setup(m => m.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
-            .Returns(redisDbMock.Object);
-
-        var options = new DbContextOptionsBuilder<BreastCancerDB>()
-            .UseInMemoryDatabase($"feed-test-{Guid.NewGuid()}")
-            .Options;
-
-        await using var dbContext = new BreastCancerDB(options);
-        var loggerMock = new Mock<ILogger<GetFeedQueryHandler>>();
-
-        var now = DateTime.UtcNow;
-        dbContext.Follows.Add(new Follow { FollowerId = "user-1", FollowingId = "author-1" });
-
-        dbContext.Posts.AddRange(
-            new Post { Id = 10, AuthorId = "author-1", Content = "p1", CreatedAt = now },
-            new Post { Id = 9, AuthorId = "author-1", Content = "p2", CreatedAt = now.AddMinutes(-1) },
-            new Post { Id = 8, AuthorId = "author-1", Content = "p3", CreatedAt = now.AddMinutes(-2) });
-
-        await dbContext.SaveChangesAsync();
-
-        var handler = new GetFeedQueryHandler(multiplexerMock.Object, dbContext, loggerMock.Object);
-
-        var result = await handler.Handle(new GetFeedQuery("user-1", null, 2), CancellationToken.None);
-
-        result.PostIds.Should().Equal(new[] { 10, 9 });
-        result.NextCursor.Should().Be(9);
+        stringSetCallCount.Should().Be(5);
     }
 }

--- a/BreastCancer.Tests/Integration/FeedVisibilityTests.cs
+++ b/BreastCancer.Tests/Integration/FeedVisibilityTests.cs
@@ -1,5 +1,6 @@
 using BreastCancer.Community.DTO.response;
 using BreastCancer.Community.Features.Feed;
+using BreastCancer.Community.Services.Interface;
 using BreastCancer.Context;
 using BreastCancer.Enum;
 using BreastCancer.Models;
@@ -56,6 +57,8 @@ public sealed class FeedVisibilityTests
         await using var dbContext = new BreastCancerDB(options);
         var loggerMock = new Mock<ILogger<GetFeedQueryHandler>>();
 
+        var cacheServiceMock = new Mock<ICacheService>();
+
         var userId = "user-1";
         var authorId = "author-1";
 
@@ -66,12 +69,12 @@ public sealed class FeedVisibilityTests
 
         await dbContext.SaveChangesAsync();
 
-        var handler = new GetFeedQueryHandler(multiplexerMock.Object, dbContext, loggerMock.Object);
+        var handler = new GetFeedQueryHandler(multiplexerMock.Object, dbContext, cacheServiceMock.Object, loggerMock.Object);
 
         var query = new GetFeedQuery(userId, null, 10, roles);
         var result = await handler.Handle(query, CancellationToken.None);
 
-        var contains = result.PostIds.Contains(1);
+        var contains = result.Posts.Any(p => p.Id == 1);
         contains.Should().Be(expectedVisible);
     }
 
@@ -105,6 +108,8 @@ public sealed class FeedVisibilityTests
         await using var dbContext = new BreastCancerDB(options);
         var loggerMock = new Mock<ILogger<GetFeedQueryHandler>>();
 
+        var cacheServiceMock = new Mock<ICacheService>();
+
         var userId = "user-1";
         var authorId = "author-1";
 
@@ -112,12 +117,12 @@ public sealed class FeedVisibilityTests
 
         await dbContext.SaveChangesAsync();
 
-        var handler = new GetFeedQueryHandler(multiplexerMock.Object, dbContext, loggerMock.Object);
+        var handler = new GetFeedQueryHandler(multiplexerMock.Object, dbContext, cacheServiceMock.Object, loggerMock.Object);
 
         var query = new GetFeedQuery(userId, null, 10, roles);
         var result = await handler.Handle(query, CancellationToken.None);
 
-        var contains = result.PostIds.Contains(1);
+        var contains = result.Posts.Any(p => p.Id == 1);
         contains.Should().Be(expectedVisible);
     }
 }

--- a/Community/DTO/response/FeedResponseDto.cs
+++ b/Community/DTO/response/FeedResponseDto.cs
@@ -2,6 +2,6 @@ namespace BreastCancer.Community.DTO.response;
 
 public sealed class FeedResponseDto
 {
-    public IReadOnlyList<int> PostIds { get; init; } = Array.Empty<int>();
+    public IReadOnlyList<PostDTO> Posts { get; init; } = Array.Empty<PostDTO>();
     public int? NextCursor { get; init; }
 }

--- a/Community/Features/Feed/GetFeedQueryHandler.cs
+++ b/Community/Features/Feed/GetFeedQueryHandler.cs
@@ -1,6 +1,8 @@
 using BreastCancer.Community.DTO.response;
+using BreastCancer.Community.Services.Interface;
 using BreastCancer.Context;
 using BreastCancer.Enum;
+using BreastCancer.Models;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using StackExchange.Redis;
@@ -10,14 +12,23 @@ namespace BreastCancer.Community.Features.Feed;
 public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResponseDto>
 {
     private const string FeedKeyPrefix = "rehla:community:feed:";
+    private const string PostCacheKeyPrefix = "post:";
+    private static readonly TimeSpan PostCacheTtl = TimeSpan.FromHours(1);
+
     private readonly IConnectionMultiplexer _connectionMultiplexer;
     private readonly BreastCancerDB _dbContext;
+    private readonly ICacheService _cacheService;
     private readonly ILogger<GetFeedQueryHandler> _logger;
 
-    public GetFeedQueryHandler(IConnectionMultiplexer connectionMultiplexer, BreastCancerDB dbContext, ILogger<GetFeedQueryHandler> logger)
+    public GetFeedQueryHandler(
+        IConnectionMultiplexer connectionMultiplexer,
+        BreastCancerDB dbContext,
+        ICacheService cacheService,
+        ILogger<GetFeedQueryHandler> logger)
     {
         _connectionMultiplexer = connectionMultiplexer ?? throw new ArgumentNullException(nameof(connectionMultiplexer));
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -34,77 +45,50 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         var redisDb = _connectionMultiplexer.GetDatabase();
         var feedKey = BuildFeedKey(request.UserId);
 
+        List<int>? feedIds = null;
+
         if (await redisDb.KeyExistsAsync(feedKey))
         {
-            _logger.LogInformation("Feed cache hit for user {UserId}; retrieving feed from Redis.", request.UserId);
-            return await GetRedisFeedAsync(request, allowedVisibilities, normalizedLimit, redisDb, feedKey, cancellationToken);
+            feedIds = await GetFeedIdsFromRedisAsync(request, normalizedLimit, redisDb, feedKey);
+
+            if (feedIds != null)
+            {
+                _logger.LogInformation("Feed cache hit for user {UserId}; retrieving feed IDs from Redis.", request.UserId);
+            }
+            else
+            {
+                _logger.LogInformation("Feed cache hit, but cursor {Cursor} not found in Redis. Falling back to SQL for deep pagination.", request.Cursor);
+            }
         }
 
-        _logger.LogInformation("Feed cache miss for user {UserId}; falling back to SQL feed query.", request.UserId);
-        return await GetSqlFeedAsync(request, roleFlags, normalizedLimit, cancellationToken);
-    }
-
-    private async Task<FeedResponseDto> GetRedisFeedAsync(
-        GetFeedQuery request,
-        IReadOnlySet<PostVisibility> allowedVisibilities,
-        int normalizedLimit,
-        IDatabase redisDb,
-        string feedKey,
-        CancellationToken cancellationToken)
-    {
-        var batchSize = normalizedLimit + 1;
-        var visibleOrdered = new List<int>();
-        var start = await GetRedisStartRankAsync(redisDb, feedKey, request.Cursor);
-        var exhausted = false;
-
-        while (visibleOrdered.Count < normalizedLimit + 1)
+        if (feedIds == null)
         {
-            var batch = await redisDb.SortedSetRangeByRankAsync(feedKey, start, start + batchSize - 1, Order.Descending);
-            if (batch.Length == 0)
-            {
-                exhausted = true;
-                break;
-            }
-
-            var idsOrdered = batch.Select(v => (int)v).ToList();
-
-            var posts = await _dbContext.Posts.AsNoTracking()
-                .Where(p => idsOrdered.Contains(p.Id) && !p.IsDeleted)
-                .Select(p => new { p.Id, p.Visibility })
-                .ToListAsync(cancellationToken);
-
-            var postsById = posts.ToDictionary(p => p.Id);
-            foreach (var id in idsOrdered)
-            {
-                if (visibleOrdered.Count >= normalizedLimit + 1)
-                {
-                    break;
-                }
-
-                if (!postsById.TryGetValue(id, out var p))
-                {
-                    continue;
-                }
-
-                if (allowedVisibilities.Contains(p.Visibility))
-                {
-                    visibleOrdered.Add(id);
-                }
-            }
-
-            if (batch.Length < batchSize)
-            {
-                exhausted = true;
-                break;
-            }
-
-            start += batch.Length;
+            _logger.LogInformation("Feed cache miss for user {UserId}; falling back to SQL feed query.", request.UserId);
+            feedIds = await GetFeedIdsFromSqlAsync(request, roleFlags, normalizedLimit, cancellationToken);
         }
 
-        return BuildResponse(visibleOrdered, normalizedLimit);
+        var hydratedPosts = await HydratePostsAsync(feedIds, roleFlags, cancellationToken);
+        return BuildResponse(hydratedPosts, normalizedLimit);
     }
 
-    private async Task<FeedResponseDto> GetSqlFeedAsync(
+    private async Task<List<int>?> GetFeedIdsFromRedisAsync(
+            GetFeedQuery request,
+            int normalizedLimit,
+            IDatabase redisDb,
+            string feedKey)
+    {
+        var fetchLimit = normalizedLimit * 2;
+
+        var start = await GetRedisStartRankAsync(redisDb, feedKey, request.Cursor);
+
+        if (start == null) return null;
+
+        var batch = await redisDb.SortedSetRangeByRankAsync(feedKey, start.Value, start.Value + fetchLimit, Order.Descending);
+
+        return batch.Select(v => (int)v).ToList();
+    }
+
+    private async Task<List<int>> GetFeedIdsFromSqlAsync(
         GetFeedQuery request,
         RoleFlags roleFlags,
         int normalizedLimit,
@@ -133,11 +117,9 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
             }
         }
 
-        var rawPosts = await query
+        return await query
             .Where(p => p.Visibility == PostVisibility.Public
-                || (roleFlags.IsDoctor && (p.Visibility == PostVisibility.DoctorOnly
-                    || p.Visibility == PostVisibility.PatientsOnly
-                    || p.Visibility == PostVisibility.CaregiverOnly))
+                || (roleFlags.IsDoctor && (p.Visibility == PostVisibility.DoctorOnly || p.Visibility == PostVisibility.PatientsOnly || p.Visibility == PostVisibility.CaregiverOnly))
                 || (!roleFlags.IsDoctor && roleFlags.IsPatient && p.Visibility == PostVisibility.PatientsOnly)
                 || (!roleFlags.IsDoctor && roleFlags.IsCaregiver && p.Visibility == PostVisibility.CaregiverOnly))
             .OrderByDescending(p => p.CreatedAt)
@@ -145,44 +127,94 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
             .Take(normalizedLimit + 1)
             .Select(p => p.Id)
             .ToListAsync(cancellationToken);
-
-        return BuildResponse(rawPosts, normalizedLimit);
     }
 
-    private static FeedResponseDto BuildResponse(List<int> visibleOrdered, int normalizedLimit)
+    private async Task<List<PostDTO>> HydratePostsAsync(
+        List<int> postIds,
+        RoleFlags roleFlags,
+        CancellationToken cancellationToken)
     {
-        var visiblePage = visibleOrdered.Take(normalizedLimit).ToList();
-        var hasVisibleMore = visibleOrdered.Count > normalizedLimit;
+        if (postIds.Count == 0) return new List<PostDTO>();
+
+        var results = new Dictionary<int, PostDTO>(postIds.Count);
+        var missedIds = new List<int>();
+
+        // 1. Check Cache 
+        foreach (var id in postIds)
+        {
+            var cacheKey = $"{PostCacheKeyPrefix}{id}";
+            var post = await _cacheService.GetAsync<PostDTO>(cacheKey, cancellationToken);
+
+            if (post != null)
+                results[id] = post;
+            else
+                missedIds.Add(id);
+        }
+
+        // 2. Cache Miss - Hydrate from DB
+        if (missedIds.Any())
+        {
+            var postsFromDb = await _dbContext.Posts
+                .AsNoTracking()
+                .Include(p => p.Author)
+                .Where(p => missedIds.Contains(p.Id) && !p.IsDeleted)
+                .Select(p => new PostDTO
+                {
+                    Id = p.Id,
+                    AuthorId = p.AuthorId,
+                    Content = p.Content,
+                    PostType = p.Type,
+                    PostVisibility = p.Visibility,
+                    MediaUrls = p.MediaUrls,
+                    CreatedAt = p.CreatedAt,
+                    UpdatedAt = p.UpdatedAt,
+                    IsEdited = p.IsEdited
+                })
+                .ToListAsync(cancellationToken);
+
+            foreach (var post in postsFromDb)
+            {
+                var cacheKey = $"{PostCacheKeyPrefix}{post.Id}";
+                await _cacheService.SetAsync(cacheKey, post, PostCacheTtl, cancellationToken);
+                results[post.Id] = post;
+            }
+
+            foreach (var id in missedIds)
+            {
+                if (!results.ContainsKey(id))
+                    _logger.LogWarning("Post {PostId} not found in database during hydration", id);
+            }
+        }
+
+        var allowedVisibilities = GetAllowedVisibilities(roleFlags);
+        return postIds
+            .Where(id => results.ContainsKey(id) && allowedVisibilities.Contains(results[id].PostVisibility))
+            .Select(id => results[id])
+            .ToList();
+    }
+
+    private static FeedResponseDto BuildResponse(List<PostDTO> hydratedPosts, int normalizedLimit)
+    {
+        var page = hydratedPosts.Take(normalizedLimit).ToList();
+        var hasMore = hydratedPosts.Count > normalizedLimit;
 
         return new FeedResponseDto
         {
-            PostIds = visiblePage,
-            NextCursor = hasVisibleMore && visiblePage.Count > 0 ? visiblePage[^1] : null
+            Posts = page,
+            NextCursor = hasMore && page.Count > 0 ? page[^1].Id : null
         };
     }
 
     private static IReadOnlySet<PostVisibility> GetAllowedVisibilities(RoleFlags roles)
     {
         var allowed = new HashSet<PostVisibility> { PostVisibility.Public };
-
         if (roles.IsDoctor)
         {
-            allowed.Add(PostVisibility.DoctorOnly);
-            allowed.Add(PostVisibility.PatientsOnly);
-            allowed.Add(PostVisibility.CaregiverOnly);
+            allowed.UnionWith(new[] { PostVisibility.DoctorOnly, PostVisibility.PatientsOnly, PostVisibility.CaregiverOnly });
             return allowed;
         }
-
-        if (roles.IsPatient)
-        {
-            allowed.Add(PostVisibility.PatientsOnly);
-        }
-
-        if (roles.IsCaregiver)
-        {
-            allowed.Add(PostVisibility.CaregiverOnly);
-        }
-
+        if (roles.IsPatient) allowed.Add(PostVisibility.PatientsOnly);
+        if (roles.IsCaregiver) allowed.Add(PostVisibility.CaregiverOnly);
         return allowed;
     }
 
@@ -198,20 +230,11 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         }
     }
 
-    private static async Task<long> GetRedisStartRankAsync(IDatabase redisDb, string feedKey, int? cursor)
+    private static async Task<long?> GetRedisStartRankAsync(IDatabase redisDb, string feedKey, int? cursor)
     {
-        if (!cursor.HasValue)
-        {
-            return 0;
-        }
-
+        if (!cursor.HasValue) return 0;
         var rank = await redisDb.SortedSetRankAsync(feedKey, cursor.Value.ToString(), Order.Descending);
-        if (!rank.HasValue)
-        {
-            return 0;
-        }
-
-        return rank.Value + 1;
+        return rank.HasValue ? rank.Value + 1 : null;
     }
 
     private static string BuildFeedKey(string userId) => $"{FeedKeyPrefix}{userId}";


### PR DESCRIPTION
Closes: #108

Overview
This PR implements the cache-aside pattern for post hydration inside the feed retrieval pipeline. By checking Redis first for active post objects, it ensures that downstream feed queries can rapidly retrieve post data without hitting SQL Server unnecessarily. For any cache misses, it aggregates missing IDs into a single consolidated query to eliminate N+1 latency issues, safely updates the cache with a 1-hour expiration time, and applies role-based visibility rules server-side before rendering the final feed.

Acceptance Criteria Met:
* For each post ID: Queries community:post:{postId} from Redis to check for a warm cache hit
* On cache hit: Instantly deserializes the object and maps it directly into the feed response list
* On cache miss: Groups missing IDs into a single SELECT from community.Posts combined with an inner join on Users to parse author metadata in a single trip
* On cache miss fallback: Sets the retrieved records back into Redis with a 1-hour TTL to warm up subsequent feed read processes
* Batches database requests into a localized WHERE Id IN (...) collection instead of parsing entity records individually inside loops
* Applies strict security visibility matrices post-hydration to guarantee users only receive contents corresponding to their respective security permissions
* Included verification suites proving that a test layout containing 20 IDs with 15 hits and 5 misses issues exactly 1 SQL database query

Technical Highlights & Production Hardening:
* N+1 Query Mitigation: Consolidates cache misses dynamically using a WHERE Id IN (...) parameter list. This explicitly guards against systemic database degradation under heavy, concurrent scrolling loads.
* Multi-Tiered Security Evaluation: Performs role-based validation filters over hydrated objects completely on the server architecture. This guarantees that unauthorized roles (e.g., Caregivers viewing DoctorOnly posts) are stripped out securely before data leaves the system.
* Resilient Pagination Boundaries: Implements an engine fallback mechanism so that if a cursor index expires or evaluates to an out-of-bounds index within Redis sets, the query falls back cleanly into indexed SQL lookups rather than yielding empty results.
* Decoupled Contract Serialization: Serializes mapped PostDTO definitions rather than tracking EF Core models directly, shielding the cache from breaking database tracking contexts and runtime loops.

Testing
* Added full database integration tests simulating a variety of hit profiles (such as 15 cache hits mixed with 5 cache misses) to explicitly assert that exactly one SQL round-trip is triggered for the un-cached elements.
* Introduced localized matrix tests inside the validation suite checking all variants of post visibilities (Public, PatientsOnly, DoctorOnly, CaregiverOnly) against user profiles to verify no unauthorized entries pass the filter.
* Refactored feed endpoint controller tracking sequences to confirm correct cursor tracking and page-termination markers under real-world request simulations.