### PR TITLE
feat: implement add reactions endpoint

### DIFF
--- a/BreastCancer.Tests/Integration/CommunityControllerIntegrationTests.cs
+++ b/BreastCancer.Tests/Integration/CommunityControllerIntegrationTests.cs
@@ -10,6 +10,7 @@ using BreastCancer.Community.Features.DeletePost;
 using BreastCancer.Community.Features.Feed;
 using BreastCancer.Community.Features.GetPost;
 using BreastCancer.Community.Features.UpdatePost;
+using BreastCancer.Community.Features.Commands.AddReaction;
 using BreastCancer.Enum;
 using FluentAssertions;
 using MediatR;
@@ -215,6 +216,79 @@ public class CommunityControllerIntegrationTests
         fake.LastDeletePostCommand!.Roles.Should().Contain("MODERATOR");
     }
 
+    [Fact]
+    public async Task AddReaction_ReturnsUnauthorized_WhenNotAuthenticated()
+    {
+        await using var app = await BuildAppAsync(new FakeMediator());
+        using var client = app.GetTestClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, " ");
+
+        var response = await client.PostAsync("/api/community/posts/10/reactions?type=Like", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task AddReaction_ReturnsOk_WhenSuccessful()
+    {
+        var fake = new FakeMediator();
+        await using var app = await BuildAppAsync(fake);
+        using var client = CreateAuthenticatedClient(app, "user-1");
+
+        var response = await client.PostAsync("/api/community/posts/10/reactions?type=Like", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        fake.LastAddReactionCommand.Should().NotBeNull();
+        fake.LastAddReactionCommand!.PostId.Should().Be(10);
+        fake.LastAddReactionCommand.Type.Should().Be(ReactionType.Like);
+        fake.LastAddReactionCommand.UserId.Should().Be("user-1");
+    }
+
+    [Fact]
+    public async Task AddReaction_ReturnsConflict_WhenDuplicateReaction()
+    {
+        var fake = new FakeMediator
+        {
+            AddReactionException = new DuplicateReactionException("Conflict")
+        };
+        await using var app = await BuildAppAsync(fake);
+        using var client = CreateAuthenticatedClient(app, "user-1");
+
+        var response = await client.PostAsync("/api/community/posts/10/reactions?type=Support", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task AddReaction_ReturnsForbidden_WhenVisibilityBlocked()
+    {
+        var fake = new FakeMediator
+        {
+            AddReactionException = new PostAccessForbiddenException("Blocked")
+        };
+        await using var app = await BuildAppAsync(fake);
+        using var client = CreateAuthenticatedClient(app, "user-1");
+
+        var response = await client.PostAsync("/api/community/posts/10/reactions?type=Like", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task AddReaction_ReturnsNotFound_WhenPostDoesNotExist()
+    {
+        var fake = new FakeMediator
+        {
+            AddReactionException = new PostNotFoundException("Not Found")
+        };
+        await using var app = await BuildAppAsync(fake);
+        using var client = CreateAuthenticatedClient(app, "user-1");
+
+        var response = await client.PostAsync("/api/community/posts/999/reactions?type=Like", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
     private static HttpClient CreateAuthenticatedClient(WebApplication app, string userId, IReadOnlyCollection<string>? roles = null)
     {
         var client = app.GetTestClient();
@@ -256,6 +330,8 @@ public class CommunityControllerIntegrationTests
         public GetPostQuery? LastGetPostQuery { get; private set; }
         public UpdatePostCommand? LastUpdatePostCommand { get; private set; }
         public DeletePostCommand? LastDeletePostCommand { get; private set; }
+        public AddReactionCommand? LastAddReactionCommand { get; private set; }
+        public Exception? AddReactionException { get; set; }
         public FeedResponseDto Response { get; set; } = new FeedResponseDto
         {
             Posts = new List<PostDTO>
@@ -333,6 +409,16 @@ public class CommunityControllerIntegrationTests
                 return Task.FromResult((TResponse)(object)MediatR.Unit.Value);
             }
 
+            if (request is AddReactionCommand addReactionCommand)
+            {
+                LastAddReactionCommand = addReactionCommand;
+                if (AddReactionException is not null)
+                {
+                    return Task.FromException<TResponse>(AddReactionException);
+                }
+                return Task.FromResult((TResponse)(object)MediatR.Unit.Value);
+            }
+
             return Task.FromResult(default(TResponse)!);
         }
 
@@ -374,6 +460,16 @@ public class CommunityControllerIntegrationTests
                     return Task.FromException<object?>(DeletePostException);
                 }
 
+                return Task.FromResult<object?>(MediatR.Unit.Value);
+            }
+
+            if (request is AddReactionCommand addReactionCommandObj)
+            {
+                LastAddReactionCommand = addReactionCommandObj;
+                if (AddReactionException is not null)
+                {
+                    return Task.FromException<object?>(AddReactionException);
+                }
                 return Task.FromResult<object?>(MediatR.Unit.Value);
             }
 

--- a/BreastCancer.Tests/Integration/FanoutWorkerHighFollowerTests.cs
+++ b/BreastCancer.Tests/Integration/FanoutWorkerHighFollowerTests.cs
@@ -30,6 +30,9 @@ public sealed class FanoutWorkerHighFollowerTests
         services.AddDbContext<BreastCancerDB>(options => options.UseInMemoryDatabase(dbName, dbRoot));
         services.AddScoped<IUnitOfWork, UnitOfWork>();
 
+        var communityNotifierMock = new Mock<ICommunityNotifier>();
+        services.AddScoped<ICommunityNotifier>(_ => communityNotifierMock.Object);
+
         var dict = new Dictionary<string, string?>
         {
             { "Community:FanoutPushThreshold", "500" }
@@ -76,15 +79,12 @@ public sealed class FanoutWorkerHighFollowerTests
             Timestamp: timestamp));
         channel.Writer.Complete();
 
-        var communityNotifierMock = new Mock<ICommunityNotifier>();
-
         var worker = new FanoutWorker(
             channel,
             multiplexerMock.Object,
             provider.GetRequiredService<IServiceScopeFactory>(),
             NullLogger<FanoutWorker>.Instance,
-            provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<BreastCancer.Community.Options.CommunityOptions>>(),
-            communityNotifierMock.Object);   
+            provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<BreastCancer.Community.Options.CommunityOptions>>());   
 
         // Act
         await worker.StartAsync(CancellationToken.None);

--- a/BreastCancer.Tests/Integration/FanoutWorkerIntegrationTests.cs
+++ b/BreastCancer.Tests/Integration/FanoutWorkerIntegrationTests.cs
@@ -29,6 +29,9 @@ public sealed class FanoutWorkerIntegrationTests
         services.AddDbContext<BreastCancerDB>(options => options.UseInMemoryDatabase(dbName, dbRoot));
         services.AddScoped<IUnitOfWork, UnitOfWork>();
 
+        var communityNotifierMock = new Mock<ICommunityNotifier>();
+        services.AddScoped<ICommunityNotifier>(_ => communityNotifierMock.Object);
+
         var dict = new Dictionary<string, string?>
         {
             { "Community:FanoutPushThreshold", "500" }
@@ -108,15 +111,12 @@ public sealed class FanoutWorkerIntegrationTests
             Timestamp: timestamp));
         channel.Writer.Complete();
 
-        var communityNotifierMock = new Mock<ICommunityNotifier>();
-
         var worker = new FanoutWorker(
             channel,
             multiplexerMock.Object,
             provider.GetRequiredService<IServiceScopeFactory>(),
             NullLogger<FanoutWorker>.Instance,
-            provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<BreastCancer.Community.Options.CommunityOptions>>(),
-            communityNotifierMock.Object);   // <-- added
+            provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<BreastCancer.Community.Options.CommunityOptions>>());  
 
         // Act
         await worker.StartAsync(CancellationToken.None);

--- a/BreastCancer.Tests/Integration/PostCacheIntegrationTests.cs
+++ b/BreastCancer.Tests/Integration/PostCacheIntegrationTests.cs
@@ -125,6 +125,7 @@ public sealed class PostCacheIntegrationTests : IAsyncLifetime
     {
         private readonly BreastCancerDB _dbContext;
         private readonly IDbContextTransaction _transaction;
+        public IReactionRepository ReactionRepository => throw new NotImplementedException();
         public FakeUnitOfWork(BreastCancerDB dbContext)
         {
             _dbContext = dbContext;
@@ -169,6 +170,7 @@ public sealed class PostCacheIntegrationTests : IAsyncLifetime
     private sealed class FakePostRepository : IPostRepository
     {
         private readonly BreastCancerDB _dbContext;
+        
         public FakePostRepository(BreastCancerDB dbContext)
         {
             _dbContext = dbContext;
@@ -180,6 +182,10 @@ public sealed class PostCacheIntegrationTests : IAsyncLifetime
             await _dbContext.SaveChangesAsync();
         }
 
+        public Task<Post?> GetByIdAsync(object id)
+        {
+            throw new NotImplementedException();
+        }
         public void Add(Post entity) => _dbContext.Posts.Add(entity);
         public void Update(Post entity) => _dbContext.Posts.Update(entity);
         public void Delete(Post entity) => _dbContext.Posts.Remove(entity);

--- a/BreastCancer.Tests/Unit/AddReactionCommandHandlerTests.cs
+++ b/BreastCancer.Tests/Unit/AddReactionCommandHandlerTests.cs
@@ -1,0 +1,135 @@
+using BreastCancer.Community.Exceptions;
+using BreastCancer.Community.Features.Commands.AddReaction;
+using BreastCancer.Community.Services.Interface;
+using BreastCancer.Enum;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace BreastCancer.Tests.Unit;
+
+public sealed class AddReactionCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenPostDoesNotExist_ThrowsPostNotFoundException()
+    {
+        var sut = CreateSut();
+        sut.PostRepository.Setup(r => r.GetByIdAsync(1)).ReturnsAsync((Post?)null);
+
+        var command = new AddReactionCommand(1, ReactionType.Like, "user-1", new[] { "Patient" });
+
+        var act = async () => await sut.Handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<PostNotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenPostIsDeleted_ThrowsPostNotFoundException()
+    {
+        var sut = CreateSut();
+        sut.PostRepository.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new Post { Id = 1, IsDeleted = true });
+
+        var command = new AddReactionCommand(1, ReactionType.Like, "user-1", new[] { "Patient" });
+
+        var act = async () => await sut.Handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<PostNotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserCannotSeePost_ThrowsPostAccessForbiddenException()
+    {
+        var sut = CreateSut();
+        // Post is DoctorOnly, but the user is a Patient
+        sut.PostRepository.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new Post { Id = 1, Visibility = PostVisibility.DoctorOnly, IsDeleted = false });
+
+        var command = new AddReactionCommand(1, ReactionType.Like, "user-1", new[] { "Patient" });
+
+        var act = async () => await sut.Handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<PostAccessForbiddenException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserAlreadyReacted_ThrowsDuplicateReactionException()
+    {
+        var sut = CreateSut();
+        sut.PostRepository.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new Post { Id = 1, Visibility = PostVisibility.Public, IsDeleted = false });
+
+        sut.ReactionRepository.Setup(r => r.FilterAsync(
+            It.IsAny<Expression<Func<Reaction, bool>>>(),
+            It.IsAny<Func<IQueryable<Reaction>, IOrderedQueryable<Reaction>>?>(), 
+            It.IsAny<int?>()))
+            .ReturnsAsync(new List<Reaction> { new Reaction { Id = 10 } });
+
+        var command = new AddReactionCommand(1, ReactionType.Like, "user-1", new[] { "Patient" });
+
+        var act = async () => await sut.Handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DuplicateReactionException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenValid_SavesReactionAndIncrementsCache()
+    {
+        var sut = CreateSut();
+        sut.PostRepository.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new Post { Id = 1, Visibility = PostVisibility.Public, IsDeleted = false });
+
+        sut.ReactionRepository.Setup(r => r.FilterAsync(
+            It.IsAny<Expression<Func<Reaction, bool>>>(),
+            It.IsAny<Func<IQueryable<Reaction>, IOrderedQueryable<Reaction>>?>(), 
+            It.IsAny<int?>()))
+            .ReturnsAsync(new List<Reaction>());
+
+        var command = new AddReactionCommand(1, ReactionType.Like, "user-1", new[] { "Patient" });
+
+        var result = await sut.Handler.Handle(command, CancellationToken.None);
+
+        result.Should().Be(MediatR.Unit.Value);
+
+        sut.ReactionRepository.Verify(r => r.AddAsync(It.Is<Reaction>(reaction =>
+            reaction.PostId == 1 &&
+            reaction.UserId == "user-1" &&
+            reaction.Type == ReactionType.Like)), Times.Once);
+
+        sut.UnitOfWork.Verify(u => u.SaveAsync(), Times.Once);
+
+        sut.CacheService.Verify(c => c.IncrementHashFieldAsync(
+            "post:1:reactions",
+            ReactionType.Like.ToString(),
+            1,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static Sut CreateSut()
+    {
+        var logger = new Mock<ILogger<AddReactionCommandHandler>>();
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var cacheService = new Mock<ICacheService>();
+
+        var postRepository = new Mock<IPostRepository>();
+        var reactionRepository = new Mock<IReactionRepository>();
+
+        unitOfWork.SetupGet(u => u.PostRepository).Returns(postRepository.Object);
+        unitOfWork.SetupGet(u => u.ReactionRepository).Returns(reactionRepository.Object);
+        unitOfWork.Setup(u => u.SaveAsync()).ReturnsAsync(1);
+
+        reactionRepository.Setup(r => r.AddAsync(It.IsAny<Reaction>())).Returns(Task.CompletedTask);
+
+        var handler = new AddReactionCommandHandler(logger.Object, unitOfWork.Object, cacheService.Object);
+
+        return new Sut(handler, unitOfWork, cacheService, postRepository, reactionRepository);
+    }
+
+    private sealed record Sut(
+        AddReactionCommandHandler Handler,
+        Mock<IUnitOfWork> UnitOfWork,
+        Mock<ICacheService> CacheService,
+        Mock<IPostRepository> PostRepository,
+        Mock<IReactionRepository> ReactionRepository);
+}

--- a/BreastCancer.Tests/Unit/GetPostQueryHandlerTests.cs
+++ b/BreastCancer.Tests/Unit/GetPostQueryHandlerTests.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using BreastCancer.Community.DTO.response;
 using BreastCancer.Community.Exceptions;
 using BreastCancer.Community.Features.GetPost;
+using BreastCancer.Community.Services.Interface; 
 using BreastCancer.Context;
 using BreastCancer.Enum;
 using BreastCancer.Models;
@@ -19,7 +20,9 @@ public sealed class GetPostQueryHandlerTests
     {
         await using var dbContext = CreateDbContext();
         var mapper = CreateMapper();
-        var handler = new GetPostQueryHandler(dbContext, mapper);
+        var cacheServiceMock = new Mock<ICacheService>(); 
+
+        var handler = new GetPostQueryHandler(dbContext, mapper, cacheServiceMock.Object); 
 
         var act = async () => await handler.Handle(new GetPostQuery(1, "user-1", new[] { "Patient" }), CancellationToken.None);
 
@@ -41,7 +44,9 @@ public sealed class GetPostQueryHandlerTests
         await dbContext.SaveChangesAsync();
 
         var mapper = CreateMapper();
-        var handler = new GetPostQueryHandler(dbContext, mapper);
+        var cacheServiceMock = new Mock<ICacheService>(); 
+        
+        var handler = new GetPostQueryHandler(dbContext, mapper, cacheServiceMock.Object); 
 
         var act = async () => await handler.Handle(new GetPostQuery(1, "user-1", new[] { "Patient" }), CancellationToken.None);
 
@@ -63,7 +68,12 @@ public sealed class GetPostQueryHandlerTests
         await dbContext.SaveChangesAsync();
 
         var mapper = CreateMapper();
-        var handler = new GetPostQueryHandler(dbContext, mapper);
+        var cacheServiceMock = new Mock<ICacheService>(); 
+        
+        cacheServiceMock.Setup(c => c.GetHashAllFieldsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, long>());
+
+        var handler = new GetPostQueryHandler(dbContext, mapper, cacheServiceMock.Object);
 
         var result = await handler.Handle(new GetPostQuery(1, "user-1", new[] { "Patient" }), CancellationToken.None);
 

--- a/Community/Controllers/CommunityController.cs
+++ b/Community/Controllers/CommunityController.cs
@@ -1,21 +1,23 @@
 ﻿using BreastCancer.Community.DTO.request;
 using BreastCancer.Community.Exceptions;
-using BreastCancer.Community.Features.Feed;
-using BreastCancer.Community.Features.GetPost;
+using BreastCancer.Community.Features.Commands.AddReaction;
 using BreastCancer.Community.Features.CreatePost;
+using BreastCancer.Community.Features.DeletePost;
+using BreastCancer.Community.Features.Feed;
 using BreastCancer.Community.Features.FollowUser;
+using BreastCancer.Community.Features.GetPost;
+using BreastCancer.Community.Features.Queries.GetFollowers;
+using BreastCancer.Community.Features.Queries.GetFollowing;
 using BreastCancer.Community.Features.UnfollowUser;
+using BreastCancer.Community.Features.UpdatePost;
 using BreastCancer.Community.Security;
+using BreastCancer.Enum;
 using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Swashbuckle.AspNetCore.Annotations;
-using BreastCancer.Community.Features.UpdatePost;
-using BreastCancer.Community.Features.DeletePost;
-using BreastCancer.Community.Features.Queries.GetFollowers;
-using BreastCancer.Community.Features.Queries.GetFollowing;
 using Rehla.Community.DTO.response;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace BreastCancer.Community.Controllers
 {
@@ -269,7 +271,7 @@ namespace BreastCancer.Community.Controllers
                 return StatusCode(StatusCodes.Status403Forbidden, new { message = ex.Message });
             }
         }
-        
+
         [HttpGet("{userId}/followers")]
         [ProducesResponseType(typeof(PaginatedFollowerDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -300,6 +302,53 @@ namespace BreastCancer.Community.Controllers
             var result = await _mediator.Send(query);
             
             return Ok(result);
+        }
+
+        [HttpPost("posts/{postId:int}/reactions")]
+        [Authorize]
+        [SwaggerOperation(Summary = "Add a reaction to a post")]
+        [SwaggerResponse(StatusCodes.Status200OK, "Reaction added successfully")]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation error")]
+        [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized access")]
+        [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden")]
+        [SwaggerResponse(StatusCodes.Status404NotFound, "Post not found")]
+        [SwaggerResponse(StatusCodes.Status409Conflict, "Conflict - User has already reacted to this post")] 
+        public async Task<IActionResult> AddReaction([FromRoute] int postId, [FromQuery] ReactionType type, CancellationToken cancellationToken)
+        {
+            var userId = User.GetUserId();
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return Unauthorized(new { message = "Could not identify user" });
+            }
+
+            var roles = User.GetRoles();
+
+            try
+            {
+                await _mediator.Send(new AddReactionCommand(postId, type, userId, roles), cancellationToken);
+                return Ok(new { message = "Reaction added successfully" });
+            }
+            catch (ValidationException ex)
+            {
+                var errors = ex.Errors.Select(error => new
+                {
+                    field = error.PropertyName,
+                    message = error.ErrorMessage
+                });
+                return BadRequest(new { errors });
+            }
+            catch (DuplicateReactionException ex)
+            {
+                return Conflict(new { message = ex.Message });
+            }
+            catch (PostNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+            catch (PostAccessForbiddenException ex)
+            {
+                return StatusCode(StatusCodes.Status403Forbidden, new { message = ex.Message });
+            }
         }
     }
 }

--- a/Community/DTO/response/PostDTO.cs
+++ b/Community/DTO/response/PostDTO.cs
@@ -15,5 +15,7 @@ namespace BreastCancer.Community.DTO.response
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
         public bool IsEdited { get; set; }
+
+        public Dictionary<string, long> ReactionCounts { get; set; } = new();
     }
 }

--- a/Community/Exceptions/DuplicateReactionException.cs
+++ b/Community/Exceptions/DuplicateReactionException.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.Serialization;
+
+namespace BreastCancer.Community.Exceptions
+{
+    [Serializable]
+    public class DuplicateReactionException : Exception
+    {
+        public DuplicateReactionException( string message) : base(message) { }
+
+        private DuplicateReactionException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
+}

--- a/Community/Features/Commands/AddReaction/AddReactionCommand.cs
+++ b/Community/Features/Commands/AddReaction/AddReactionCommand.cs
@@ -1,0 +1,8 @@
+﻿using BreastCancer.Community.DTO.request;
+using BreastCancer.Enum;
+using MediatR;
+
+namespace BreastCancer.Community.Features.Commands.AddReaction
+{
+    public sealed record AddReactionCommand(int PostId, ReactionType Type, string UserId, IReadOnlyCollection<string> Roles) : IRequest<Unit>;
+}

--- a/Community/Features/Commands/AddReaction/AddReactionCommandHandler.cs
+++ b/Community/Features/Commands/AddReaction/AddReactionCommandHandler.cs
@@ -1,0 +1,82 @@
+﻿using BreastCancer.Community.Exceptions;
+using BreastCancer.Community.Services.Interface;
+using BreastCancer.Enum;
+using BreastCancer.Repository.Interface;
+using MediatR;
+
+namespace BreastCancer.Community.Features.Commands.AddReaction
+{
+    public class AddReactionCommandHandler : IRequestHandler<AddReactionCommand, Unit>
+    {
+        private readonly ILogger<AddReactionCommandHandler> _logger;
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly ICacheService _cacheService;
+
+        public AddReactionCommandHandler(
+            ILogger<AddReactionCommandHandler> logger,
+            IUnitOfWork unitOfWork,
+            ICacheService cacheService)
+        {
+            _logger = logger;
+            _unitOfWork = unitOfWork;
+            _cacheService = cacheService;
+        }
+
+        public async Task<Unit> Handle(AddReactionCommand request, CancellationToken cancellationToken)
+        {
+            var post = await _unitOfWork.PostRepository.GetByIdAsync(request.PostId);
+
+            if (post == null || post.IsDeleted)
+            {
+                throw new PostNotFoundException("Post not found.");
+            }
+
+            if (!UserCanSeePost(post.Visibility, request.Roles))
+            {
+                throw new PostAccessForbiddenException("You do not have permission to view or react to this post.");
+            }
+
+            var existingReactions = await _unitOfWork.ReactionRepository
+                .FilterAsync(r => r.PostId == request.PostId && r.UserId == request.UserId);
+
+            if (existingReactions.Any())
+            {
+                throw new DuplicateReactionException("User has already reacted to this post.");
+            }
+
+            var newReaction = new Models.Reaction
+            {
+                PostId = request.PostId,
+                UserId = request.UserId,
+                Type = request.Type
+            };
+
+            await _unitOfWork.ReactionRepository.AddAsync(newReaction);
+            await _unitOfWork.SaveAsync();
+
+            await _cacheService.IncrementHashFieldAsync(
+                $"post:{request.PostId}:reactions",
+                request.Type.ToString(),
+                1,
+                cancellationToken);
+
+            return Unit.Value;
+        }
+
+        private bool UserCanSeePost(PostVisibility visibility, IEnumerable<string> userRoles)
+        {
+            var isDoctor = userRoles.Any(r => r.Equals("Doctor", StringComparison.OrdinalIgnoreCase));
+            var isPatient = userRoles.Any(r => r.Equals("Patient", StringComparison.OrdinalIgnoreCase));
+            var isCaregiver = userRoles.Any(r => r.Equals("Caregiver", StringComparison.OrdinalIgnoreCase));
+
+            return visibility switch
+            {
+                PostVisibility.Public => true,
+                PostVisibility.DoctorOnly => isDoctor,
+                PostVisibility.PatientsOnly => isPatient || isDoctor,
+                PostVisibility.CaregiverOnly => isCaregiver || isDoctor,
+                _ => false
+            };
+        }
+    }
+}

--- a/Community/Features/Queries/GetFeed/GetFeedQueryHandler.cs
+++ b/Community/Features/Queries/GetFeed/GetFeedQueryHandler.cs
@@ -68,6 +68,9 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         }
 
         var hydratedPosts = await HydratePostsAsync(feedIds, roleFlags, cancellationToken);
+
+        await AttachReactionCountsAsync(hydratedPosts);
+
         return BuildResponse(hydratedPosts, normalizedLimit);
     }
 
@@ -235,6 +238,24 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         if (!cursor.HasValue) return 0;
         var rank = await redisDb.SortedSetRankAsync(feedKey, cursor.Value.ToString(), Order.Descending);
         return rank.HasValue ? rank.Value + 1 : null;
+    }
+
+    private async Task AttachReactionCountsAsync(List<PostDTO> posts)
+    {
+        if (posts.Count == 0) return;
+
+        var redisDb = _connectionMultiplexer.GetDatabase();
+
+        var tasks = posts.Select(async post =>
+        {
+            var hashEntries = await redisDb.HashGetAllAsync($"rehla:community:post:{post.Id}:reactions");
+
+            post.ReactionCounts = hashEntries.ToDictionary(
+                entry => entry.Name.ToString(),
+                entry => (long)entry.Value);
+        });
+
+        await Task.WhenAll(tasks);
     }
 
     private static string BuildFeedKey(string userId) => $"{FeedKeyPrefix}{userId}";

--- a/Community/Features/Queries/GetFeed/GetFeedQueryHandler.cs
+++ b/Community/Features/Queries/GetFeed/GetFeedQueryHandler.cs
@@ -69,7 +69,7 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
 
         var hydratedPosts = await HydratePostsAsync(feedIds, roleFlags, cancellationToken);
 
-        await AttachReactionCountsAsync(hydratedPosts);
+        await AttachReactionCountsAsync(hydratedPosts, cancellationToken);
 
         return BuildResponse(hydratedPosts, normalizedLimit);
     }
@@ -240,19 +240,17 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         return rank.HasValue ? rank.Value + 1 : null;
     }
 
-    private async Task AttachReactionCountsAsync(List<PostDTO> posts)
+    private async Task AttachReactionCountsAsync(List<PostDTO> posts, CancellationToken cancellationToken)
     {
         if (posts.Count == 0) return;
 
-        var redisDb = _connectionMultiplexer.GetDatabase();
-
         var tasks = posts.Select(async post =>
         {
-            var hashEntries = await redisDb.HashGetAllAsync($"rehla:community:post:{post.Id}:reactions");
+            var cacheKey = $"post:{post.Id}:reactions";
 
-            post.ReactionCounts = hashEntries.ToDictionary(
-                entry => entry.Name.ToString(),
-                entry => (long)entry.Value);
+            var hashEntries = await _cacheService.GetHashAllFieldsAsync(cacheKey, cancellationToken);
+
+            post.ReactionCounts = hashEntries ?? new Dictionary<string, long>();
         });
 
         await Task.WhenAll(tasks);

--- a/Community/Features/Queries/GetPost/GetPostQueryHandler.cs
+++ b/Community/Features/Queries/GetPost/GetPostQueryHandler.cs
@@ -1,9 +1,10 @@
 using AutoMapper;
 using BreastCancer.Community.DTO.response;
 using BreastCancer.Community.Exceptions;
+using BreastCancer.Community.Services.Interface;
 using BreastCancer.Context;
-using Microsoft.EntityFrameworkCore;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 
 namespace BreastCancer.Community.Features.GetPost;
 
@@ -11,11 +12,13 @@ public sealed class GetPostQueryHandler : IRequestHandler<GetPostQuery, PostDTO>
 {
     private readonly BreastCancerDB _dbContext;
     private readonly IMapper _mapper;
+    private readonly ICacheService _cacheService;
 
-    public GetPostQueryHandler(BreastCancerDB dbContext, IMapper mapper)
+    public GetPostQueryHandler(BreastCancerDB dbContext, IMapper mapper, ICacheService cacheService)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
     }
 
     public async Task<PostDTO> Handle(GetPostQuery request, CancellationToken cancellationToken)
@@ -34,6 +37,11 @@ public sealed class GetPostQueryHandler : IRequestHandler<GetPostQuery, PostDTO>
             throw new PostAccessForbiddenException("You are not allowed to view this post.");
         }
 
-        return _mapper.Map<PostDTO>(post);
+        var dto = _mapper.Map<PostDTO>(post);
+
+        var reactionCounts = await _cacheService.GetHashAllFieldsAsync($"post:{post.Id}:reactions", cancellationToken);
+        dto.ReactionCounts = reactionCounts;
+
+        return dto;
     }
 }

--- a/Community/Services/Implementation/RedisCacheService.cs
+++ b/Community/Services/Implementation/RedisCacheService.cs
@@ -160,5 +160,67 @@ public class RedisCacheService : ICacheService
         }
     }
 
+    public async Task IncrementHashFieldAsync(string key, string field, long incrementBy = 1, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Cache key cannot be null or empty.", nameof(key));
+        if (string.IsNullOrWhiteSpace(field))
+            throw new ArgumentException("Hash field cannot be null or empty.", nameof(field));
+        cancellationToken.ThrowIfCancellationRequested();
+        try
+        {
+            var db = _connectionMultiplexer.GetDatabase();
+            await db.HashIncrementAsync(BuildKey(key), field, incrementBy);
+            _logger.LogDebug("Incremented hash field: {Field} by {Increment} in cache key: {Key}", field, incrementBy, key);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogDebug("Cache hash increment operation cancelled for key: {Key}, field: {Field}", key, field);
+            throw;
+        }
+        catch (RedisException ex)
+        {
+            _logger.LogWarning(ex, "Redis operation failed when incrementing hash field: {Field} in key: {Key}. Cache may be out of sync.", field, key);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error incrementing hash field: {Field} in cache key: {Key}. Cache may be out of sync.", field, key);
+        }
+    }
+
+    public async Task<Dictionary<string, long>> GetHashAllFieldsAsync(string key, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Cache key cannot be null or empty.", nameof(key));
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            var db = _connectionMultiplexer.GetDatabase();
+
+            var hashEntries = await db.HashGetAllAsync(BuildKey(key));
+
+            return hashEntries.ToDictionary(
+                entry => entry.Name.ToString(),
+                entry => (long)entry.Value);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogDebug("Cache hash get all operation cancelled for key: {Key}", key);
+            throw;
+        }
+        catch (RedisException ex)
+        {
+            _logger.LogWarning(ex, "Redis operation failed when reading hash fields for key: {Key}.", key);
+            return new Dictionary<string, long>(); 
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error retrieving hash fields for key: {Key}.", key);
+            return new Dictionary<string, long>(); 
+        }
+    }
+
     private static string BuildKey(string key) => $"{KeyPrefix}{key}";
 }

--- a/Community/Services/Interface/ICacheService.cs
+++ b/Community/Services/Interface/ICacheService.cs
@@ -7,4 +7,8 @@ public interface ICacheService
     Task SetAsync<T>(string key, T value, TimeSpan? ttl = null, CancellationToken cancellationToken = default) where T : class;
 
     Task<bool> DeleteAsync(string key, CancellationToken cancellationToken = default);
+
+    Task IncrementHashFieldAsync(string key, string field, long incrementBy = 1, CancellationToken cancellationToken = default);
+
+    Task<Dictionary<string, long>> GetHashAllFieldsAsync(string key, CancellationToken cancellationToken = default);
 }

--- a/Community/Workers/Fanout/FanoutWorker.cs
+++ b/Community/Workers/Fanout/FanoutWorker.cs
@@ -6,7 +6,10 @@ using System.Threading.Channels;
 using Microsoft.Extensions.Options;
 using BreastCancer.Community.Options;
 using BreastCancer.Repository.Interface;
-using BreastCancer.Community.Services.Interface; 
+using BreastCancer.Community.Services.Interface;
+using Microsoft.Extensions.DependencyInjection; 
+using Microsoft.Extensions.Hosting; 
+using Microsoft.Extensions.Logging;
 
 namespace BreastCancer.Community.Workers.Fanout;
 
@@ -19,15 +22,13 @@ public sealed class FanoutWorker : BackgroundService
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<FanoutWorker> _logger;
     private readonly int _fanoutPushThreshold;
-    private readonly ICommunityNotifier _communityNotifier; 
 
     public FanoutWorker(
         Channel<FanoutJob> fanoutChannel,
         IConnectionMultiplexer connectionMultiplexer,
         IServiceScopeFactory scopeFactory,
         ILogger<FanoutWorker> logger,
-        IOptions<CommunityOptions> options,
-        ICommunityNotifier communityNotifier) 
+        IOptions<CommunityOptions> options)
     {
         _fanoutChannel = fanoutChannel ?? throw new ArgumentNullException(nameof(fanoutChannel));
         _connectionMultiplexer = connectionMultiplexer ?? throw new ArgumentNullException(nameof(connectionMultiplexer));
@@ -35,7 +36,6 @@ public sealed class FanoutWorker : BackgroundService
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         ArgumentNullException.ThrowIfNull(options);
         _fanoutPushThreshold = options.Value.FanoutPushThreshold;
-        _communityNotifier = communityNotifier ?? throw new ArgumentNullException(nameof(communityNotifier));
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -74,6 +74,7 @@ public sealed class FanoutWorker : BackgroundService
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<BreastCancerDB>();
+            var communityNotifier = scope.ServiceProvider.GetRequiredService<ICommunityNotifier>();
 
             var followerIds = await dbContext.Follows
                 .AsNoTracking()
@@ -106,7 +107,7 @@ public sealed class FanoutWorker : BackgroundService
             }
             else
             {
-                await HandleLowFollowerAsync(followerIds, job, cancellationToken);
+                await HandleLowFollowerAsync(followerIds, job, communityNotifier, cancellationToken);
             }
         }
         catch (OperationCanceledException)
@@ -123,7 +124,7 @@ public sealed class FanoutWorker : BackgroundService
         }
     }
 
-    private async Task HandleLowFollowerAsync(List<string> followerIds, FanoutJob job, CancellationToken cancellationToken)
+    private async Task HandleLowFollowerAsync(List<string> followerIds, FanoutJob job, ICommunityNotifier communityNotifier, CancellationToken cancellationToken)
     {
         var redisDb = _connectionMultiplexer.GetDatabase();
         var score = job.Timestamp.ToUnixTimeSeconds();
@@ -150,7 +151,7 @@ public sealed class FanoutWorker : BackgroundService
 
         foreach (var followerId in followerIds)
         {
-            _ = _communityNotifier.NotifyNewPostAsync(followerId, job.PostId.ToString());
+            _ = communityNotifier.NotifyNewPostAsync(followerId, job.PostId.ToString());
         }
     }
 

--- a/Context/BreastCancerDB.cs
+++ b/Context/BreastCancerDB.cs
@@ -292,6 +292,21 @@ namespace BreastCancer.Context
 
             builder.Entity<HighFollowerPost>()
                 .HasKey(h => h.Id);
+
+            builder.Entity<Reaction>()
+                .ToTable("Reactions", "community");
+
+            builder.Entity<Reaction>()
+                .HasIndex(reaction => new { reaction.PostId, reaction.UserId })
+                .IsUnique();
+
+            builder.Entity<Reaction>()
+                .HasQueryFilter(reaction => !reaction.Post.IsDeleted);
+
+            builder.Entity<Reaction>()
+                .Property(reaction => reaction.Type)
+                .HasConversion<string>()
+                .HasMaxLength(50);
         }
 
     }

--- a/Migrations/20260606191741_PreventDuplicateReactions.Designer.cs
+++ b/Migrations/20260606191741_PreventDuplicateReactions.Designer.cs
@@ -4,6 +4,7 @@ using BreastCancer.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BreastCancer.Migrations
 {
     [DbContext(typeof(BreastCancerDB))]
-    partial class BreastCancerDBModelSnapshot : ModelSnapshot
+    [Migration("20260606191741_PreventDuplicateReactions")]
+    partial class PreventDuplicateReactions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260606191741_PreventDuplicateReactions.cs
+++ b/Migrations/20260606191741_PreventDuplicateReactions.cs
@@ -1,0 +1,119 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BreastCancer.Migrations
+{
+    /// <inheritdoc />
+    public partial class PreventDuplicateReactions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Reactions_PostId",
+                schema: "community",
+                table: "Reactions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Follows_FollowingId",
+                schema: "community",
+                table: "Follows");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "1",
+                column: "ConcurrencyStamp",
+                value: "fc628ff3-201e-448a-8cfb-c24740a90b38");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "2",
+                column: "ConcurrencyStamp",
+                value: "302d1b74-b11e-4fcb-aa26-3fd3454a90db");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "3",
+                column: "ConcurrencyStamp",
+                value: "9e7cc21a-9c39-4b67-a895-af68974e2f0e");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "4",
+                column: "ConcurrencyStamp",
+                value: "afa4f131-7ee3-46ce-b34a-5b0b13ab879b");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Reactions_PostId_UserId",
+                schema: "community",
+                table: "Reactions",
+                columns: new[] { "PostId", "UserId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Follows_FollowingId_CreatedAt",
+                schema: "community",
+                table: "Follows",
+                columns: new[] { "FollowingId", "CreatedAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Reactions_PostId_UserId",
+                schema: "community",
+                table: "Reactions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Follows_FollowingId_CreatedAt",
+                schema: "community",
+                table: "Follows");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "1",
+                column: "ConcurrencyStamp",
+                value: "38b77973-9234-4384-b1c0-aea7e9ae6a77");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "2",
+                column: "ConcurrencyStamp",
+                value: "aa42989d-c18a-4f8e-a90d-a5cf256eef31");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "3",
+                column: "ConcurrencyStamp",
+                value: "523e514f-6135-4425-82eb-f48049a36b03");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "4",
+                column: "ConcurrencyStamp",
+                value: "e3fb2cc0-a6de-41f8-82f3-9c72220b5b9e");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Reactions_PostId",
+                schema: "community",
+                table: "Reactions",
+                column: "PostId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Follows_FollowingId",
+                schema: "community",
+                table: "Follows",
+                column: "FollowingId");
+        }
+    }
+}

--- a/Repository/Interface/IGenericRepository.cs
+++ b/Repository/Interface/IGenericRepository.cs
@@ -5,7 +5,7 @@ namespace BreastCancer.Repository.Interface
     public interface IGenericRepository<T> where T : class 
     {
         Task<IEnumerable<T>> GetAllAsync();
-        Task<T?> GetByIdAsync(string id);
+        Task<T?> GetByIdAsync(object id);
         Task AddAsync(T entity);
         void Add(T entity);
         void Update(T entity);

--- a/Repository/Interface/IReactionRepository.cs
+++ b/Repository/Interface/IReactionRepository.cs
@@ -1,0 +1,8 @@
+﻿using BreastCancer.Models;
+
+namespace BreastCancer.Repository.Interface
+{
+    public interface IReactionRepository : IGenericRepository<Reaction>
+    {
+    }
+}

--- a/Repository/Interface/IUnitOfWork.cs
+++ b/Repository/Interface/IUnitOfWork.cs
@@ -18,6 +18,8 @@ namespace BreastCancer.Repository.Interface
         INotificationRepository NotificationRepository { get; }
         IHighFollowerPostRepository HighFollowerPostRepository { get; }
 
+        IReactionRepository ReactionRepository { get; }
+
         Task<IDbContextTransaction> BeginTransactionAsync();
 
         Task<int> SaveAsync();

--- a/Repository/Repositories/GenericRepository.cs
+++ b/Repository/Repositories/GenericRepository.cs
@@ -38,7 +38,7 @@ namespace BreastCancer.Repository.Repositories
             return await _dbSet.ToListAsync();
         }
 
-        public async Task<T?> GetByIdAsync(string id)
+        public async Task<T?> GetByIdAsync(object id)
         {
             return await _dbSet.FindAsync(id);
         }

--- a/Repository/Repositories/ReactionRepository.cs
+++ b/Repository/Repositories/ReactionRepository.cs
@@ -1,0 +1,13 @@
+﻿using BreastCancer.Context;
+using BreastCancer.Models;
+using BreastCancer.Repository.Interface;
+
+namespace BreastCancer.Repository.Repositories
+{
+    public class ReactionRepository : GenericRepository<Reaction>, IReactionRepository
+    {
+        public ReactionRepository(BreastCancerDB _Context) : base(_Context)
+        {
+        }
+    }
+}

--- a/Repository/Repositories/UnitOfWork.cs
+++ b/Repository/Repositories/UnitOfWork.cs
@@ -20,6 +20,7 @@ namespace BreastCancer.Repository.Repositories
         private IFollowRepository _followRepository;
         private INotificationRepository _notificationRepository;
         private IHighFollowerPostRepository _highFollowerPostRepository;
+        private IReactionRepository _reactionRepository;
 
         public UnitOfWork(BreastCancerDB Context)
         {
@@ -140,6 +141,18 @@ namespace BreastCancer.Repository.Repositories
                     _highFollowerPostRepository = new HighFollowerPostRepository(context);
                 }
                 return _highFollowerPostRepository;
+            }
+        }
+
+        public IReactionRepository ReactionRepository
+        {
+            get
+            {
+                if (_reactionRepository == null)
+                {
+                    _reactionRepository = new ReactionRepository(context);
+                }
+                return _reactionRepository;
             }
         }
 


### PR DESCRIPTION
Closes: #113

**Overview**
Implements the ability for users to add reactions (Heart, Support, Strong) to community posts. Reaction counts are managed entirely via highly optimized Redis Hashes to guarantee zero SQL queries on read. *(Note: Delete reaction functionality will follow in a separate PR).*

**Acceptance Criteria Met**

* Added `POST /community/posts/{postId}/reactions` to add a reaction
* Enforced one reaction per user per post (returns 409 Conflict)
* Enforced post visibility rules (returns 403 Forbidden)
* Reaction counts cached in Redis: `community:post:{id}:reactions` as a Hash
* Added `HINCRBY` operation to CacheService for lightweight increments
* Reaction counts per type returned on every post/feed response

**Technical Highlights**

* Zero SQL queries for retrieving reaction counts on read pathways
* Enum-based design keeps the implementation simple for the initial 3 reaction types
* *Includes chore:* Fixed `FanoutWorker` captive dependency crash and removed test packages from production `.csproj`

**Testing**

* Valid reaction successfully saves to SQL and increments Redis hash
* Duplicate reaction attempt correctly throws and returns 409 Conflict
* Reacting to a restricted post throws and returns 403 Forbidden
* Full unit and HTTP integration tests implemented for the Add Reaction handler and POST endpoint