### PR TITLE
fix: resolve null fields in Patient and Doctor responses by adding eager loading

### DIFF
--- a/Repository/Repositories/DoctorRepository.cs
+++ b/Repository/Repositories/DoctorRepository.cs
@@ -14,15 +14,15 @@ namespace BreastCancer.Repository.Repositories
 
         public async Task<Doctor?> GetByIdAsync(string id)
         {
-            // Rely on EF Core lazy loading proxies to load navigation properties (User, Patients)
-            return await _dbSet.FirstOrDefaultAsync(d => d.UserId == id);
+            return await _dbSet
+                .Include(d => d.User)
+                .FirstOrDefaultAsync(d => d.UserId == id);
         }
 
         public async Task<IEnumerable<Doctor>> GetPagedAsync(int pageNumber, int pageSize)
         {
-            // Rely on EF Core lazy loading proxies for navigation properties (User, Patients)
-            // Pagination is applied only to the Doctor set
             return await _dbSet
+                .Include(d => d.User)
                 .Skip((pageNumber - 1) * pageSize)
                 .Take(pageSize)
                 .ToListAsync();

--- a/Repository/Repositories/PatientRepository.cs
+++ b/Repository/Repositories/PatientRepository.cs
@@ -14,8 +14,24 @@ namespace BreastCancer.Repository.Repositories
 
         public async Task<Patient?> GetByIdAsync(string id)
         {
-            // Rely on EF Core lazy loading proxies to load navigation properties (User, Doctor, Caregivers)
-            return await _dbSet.FirstOrDefaultAsync(p => p.UserId == id);
+            return await _dbSet
+                .Include(p => p.User)
+                .Include(p => p.Doctor)
+                    .ThenInclude(d => d.User)
+                .Include(p => p.TreatmentPlan)
+                .FirstOrDefaultAsync(p => p.UserId == id);
+        }
+
+        public async Task<IEnumerable<Patient>> GetPagedAsync(int pageNumber, int pageSize)
+        {
+            return await _dbSet
+                .Include(p => p.User)
+                .Include(p => p.Doctor)
+                    .ThenInclude(d => d.User)
+                .Include(p => p.TreatmentPlan)
+                .Skip((pageNumber - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync();
         }
         public async Task<Patient?> GetByEmailAsync(string Email)
         {
@@ -30,16 +46,6 @@ namespace BreastCancer.Repository.Repositories
                 .FirstOrDefaultAsync(p => p.UserId == patientId);
 
             return patient;
-        }
-
-        public async Task<IEnumerable<Patient>> GetPagedAsync(int pageNumber, int pageSize)
-        {
-            // Rely on EF Core lazy loading proxies for navigation properties (User, Doctor, Caregivers)
-            // Pagination is applied only to the Patient set
-            return await _dbSet
-                .Skip((pageNumber - 1) * pageSize)
-                .Take(pageSize)
-                .ToListAsync();
         }
 
         //public async Task<IEnumerable<Patient>> GetAllWithDoctorAndCaregiverAsync()


### PR DESCRIPTION
## Problem
GET /api/Patient and GET /api/Doctor returned null for all ApplicationUser-derived 
fields (firstName, lastName, email, isActive, createdAt, etc.) despite the data 
existing in the database.

Both repositories relied on EF Core lazy loading for the User navigation property. 
Because the DbContext is disposed before the service layer hands the entities to 
AutoMapper, the proxies never fire and p.User / d.User are null at mapping time. 
AutoMapper's IncludeMembers then maps from a null source, leaving every field at 
its default.

## Fix
Replaced lazy loading with explicit Include chains in all affected query methods.

**PatientRepository**
- GetByIdAsync: Include(p => p.User), Include(p => p.Doctor).ThenInclude(d => d.User), Include(p => p.TreatmentPlan)
- GetPagedAsync: same includes + pagination

**DoctorRepository**
- GetByIdAsync: Include(d => d.User)
- GetPagedAsync: same include + pagination

## Testing
- GET /api/Patient and GET /api/Patient/{id} now return all user fields correctly
- GET /api/Doctor and GET /api/Doctor/{id} now return all user fields correctly
- doctorName on PatientResponseDTO populates correctly when a doctor is assigned

Closes #150 , Closes #151 