### PR TITLE
feat: implement user search endpoint

### DIFF
--- a/BreastCancer.Tests/Integration/CommunityControllerIntegrationTests.cs
+++ b/BreastCancer.Tests/Integration/CommunityControllerIntegrationTests.cs
@@ -12,6 +12,7 @@ using BreastCancer.Community.Features.GetPost;
 using BreastCancer.Community.Features.UpdatePost;
 using BreastCancer.Community.Features.Commands.AddReaction;
 using BreastCancer.Community.Features.Commands.RemoveReaction;
+using BreastCancer.Community.Features.Queries.SearchUsers;
 using BreastCancer.Enum;
 using FluentAssertions;
 using MediatR;
@@ -347,6 +348,85 @@ public class CommunityControllerIntegrationTests
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
+    [Fact]
+    public async Task SearchUsers_ReturnsUnauthorized_WhenNotAuthenticated()
+    {
+        await using var app = await BuildAppAsync(new FakeMediator());
+        using var client = app.GetTestClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, " ");
+
+        // Act
+        var response = await client.GetAsync("/api/community/users/search?query=John");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task SearchUsers_ReturnsBadRequest_WhenQueryIsEmpty()
+    {
+        var fake = new FakeMediator();
+        await using var app = await BuildAppAsync(fake);
+        using var client = CreateAuthenticatedClient(app, "user-1");
+
+        // Act - Notice the empty query parameter
+        var response = await client.GetAsync("/api/community/users/search?query=");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task SearchUsers_ReturnsOk_WithUsersFromMediator()
+    {
+        // Arrange
+        var fake = new FakeMediator();
+        fake.SearchUsersResponse = new List<UserSearchDto>
+        {
+            new("user-2", "John Doe", "john@example.com", "http://avatar.url/john.jpg"),
+            new("user-3", "Jane Doe", "jane@example.com", "http://avatar.url/jane.jpg")
+        };
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = CreateAuthenticatedClient(app, "user-1");
+
+        // Act
+        var response = await client.GetAsync("/api/community/users/search?query=Doe&limit=15");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var payload = await response.Content.ReadFromJsonAsync<List<UserSearchDto>>();
+        payload.Should().NotBeNull();
+        payload.Should().HaveCount(2);
+        payload!.Select(u => u.Name).Should().ContainInOrder("John Doe", "Jane Doe");
+
+        fake.LastSearchUsersQuery.Should().NotBeNull();
+        fake.LastSearchUsersQuery!.SearchTerm.Should().Be("Doe");
+        fake.LastSearchUsersQuery.Limit.Should().Be(15);
+    }
+
+    [Fact]
+    public async Task SearchUsers_ReturnsOk_WithEmptyList_WhenNoUsersFound()
+    {
+        // Arrange
+        var fake = new FakeMediator();
+        fake.SearchUsersResponse = new List<UserSearchDto>(); // Returns empty list
+
+        await using var app = await BuildAppAsync(fake);
+        using var client = CreateAuthenticatedClient(app, "user-1");
+
+        // Act
+        var response = await client.GetAsync("/api/community/users/search?query=NonExistentPerson");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var payload = await response.Content.ReadFromJsonAsync<List<UserSearchDto>>();
+        payload.Should().NotBeNull();
+        payload.Should().BeEmpty(); 
+    }
+
     private static HttpClient CreateAuthenticatedClient(WebApplication app, string userId, IReadOnlyCollection<string>? roles = null)
     {
         var client = app.GetTestClient();
@@ -390,6 +470,10 @@ public class CommunityControllerIntegrationTests
         public DeletePostCommand? LastDeletePostCommand { get; private set; }
         public AddReactionCommand? LastAddReactionCommand { get; private set; }
         public RemoveReactionCommand? LastRemoveReactionCommand { get; private set; } 
+        
+        public SearchUsersQuery? LastSearchUsersQuery { get; private set; }
+        public List<UserSearchDto>? SearchUsersResponse { get; set; } = new();
+
         public Exception? AddReactionException { get; set; }
         public Exception? RemoveReactionException { get; set; } 
 
@@ -490,6 +574,12 @@ public class CommunityControllerIntegrationTests
                 return Task.FromResult((TResponse)(object)MediatR.Unit.Value);
             }
 
+            if (request is SearchUsersQuery searchUsersQuery)
+            {
+                LastSearchUsersQuery = searchUsersQuery;
+                return Task.FromResult((TResponse)(object)(SearchUsersResponse ?? new List<UserSearchDto>()));
+            }
+
             return Task.FromResult(default(TResponse)!);
         }
 
@@ -552,6 +642,12 @@ public class CommunityControllerIntegrationTests
                     return Task.FromException<object?>(RemoveReactionException);
                 }
                 return Task.FromResult<object?>(MediatR.Unit.Value);
+            }
+
+            if (request is SearchUsersQuery searchUsersQueryObj)
+            {
+                LastSearchUsersQuery = searchUsersQueryObj;
+                return Task.FromResult<object?>(SearchUsersResponse ?? new List<UserSearchDto>());
             }
 
             return Task.FromResult<object?>(null);

--- a/BreastCancer.Tests/Unit/SearchUsersQueryHandlerTests.cs
+++ b/BreastCancer.Tests/Unit/SearchUsersQueryHandlerTests.cs
@@ -1,0 +1,165 @@
+using BreastCancer.Community.Features.Queries.SearchUsers;
+using BreastCancer.Context;
+using BreastCancer.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace BreastCancer.Tests.Unit;
+
+public class SearchUsersQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_WithNoMatches_ReturnsEmptyList()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<BreastCancerDB>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        using (var context = new BreastCancerDB(options))
+        {
+            context.Users.Add(new ApplicationUser { Id = "1", FirstName = "John", LastName = "Doe", Email = "john@test.com" });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new BreastCancerDB(options))
+        {
+            var handler = new SearchUsersQueryHandler(context);
+            var query = new SearchUsersQuery("Zebra", 20);
+
+            // Act
+            var result = await handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task Handle_SearchByName_ReturnsMatchingUsers_SortedByFirstName()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<BreastCancerDB>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        using (var context = new BreastCancerDB(options))
+        {
+            context.Users.AddRange(new List<ApplicationUser>
+            {
+                new() { Id = "1", FirstName = "Alice", LastName = "Smith", Email = "alice@test.com" },
+                new() { Id = "2", FirstName = "Bob", LastName = "Smith", Email = "bob@test.com" },
+                new() { Id = "3", FirstName = "Charlie", LastName = "Brown", Email = "charlie@test.com" }
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new BreastCancerDB(options))
+        {
+            var handler = new SearchUsersQueryHandler(context);
+            var query = new SearchUsersQuery("Smith", 20); 
+
+            // Act
+            var result = await handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.Should().HaveCount(2);
+            result.Select(u => u.Name).Should().ContainInOrder("Alice Smith", "Bob Smith");
+        }
+    }
+
+    [Fact]
+    public async Task Handle_SearchByEmail_ReturnsMatchingUser()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<BreastCancerDB>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        using (var context = new BreastCancerDB(options))
+        {
+            context.Users.AddRange(new List<ApplicationUser>
+            {
+                new() { Id = "1", FirstName = "John", LastName = "Doe", Email = "john.doe@hospital.com" },
+                new() { Id = "2", FirstName = "Jane", LastName = "Doe", Email = "jane.doe@clinic.com" }
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new BreastCancerDB(options))
+        {
+            var handler = new SearchUsersQueryHandler(context);
+            var query = new SearchUsersQuery("hospital.com", 20); 
+
+            // Act
+            var result = await handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.Should().ContainSingle();
+            result.First().Email.Should().Be("john.doe@hospital.com");
+        }
+    }
+
+    [Fact]
+    public async Task Handle_SearchByExactId_ReturnsMatchingUser()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<BreastCancerDB>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        using (var context = new BreastCancerDB(options))
+        {
+            context.Users.AddRange(new List<ApplicationUser>
+            {
+                new() { Id = "user-123", FirstName = "Test", LastName = "User", Email = "test@test.com" },
+                new() { Id = "user-456", FirstName = "Another", LastName = "User", Email = "another@test.com" }
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new BreastCancerDB(options))
+        {
+            var handler = new SearchUsersQueryHandler(context);
+            var query = new SearchUsersQuery("user-456", 20); 
+
+            // Act
+            var result = await handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.Should().ContainSingle();
+            result.First().Id.Should().Be("user-456");
+        }
+    }
+
+    [Fact]
+    public async Task Handle_WithLimitExceeded_ReturnsOnlyLimitedAmount()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<BreastCancerDB>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        using (var context = new BreastCancerDB(options))
+        {
+            var users = Enumerable.Range(1, 5).Select(i => 
+                new ApplicationUser { Id = i.ToString(), FirstName = "Clone", LastName = "Trooper", Email = $"clone{i}@test.com" }
+            );
+            context.Users.AddRange(users);
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new BreastCancerDB(options))
+        {
+            var handler = new SearchUsersQueryHandler(context);
+            var query = new SearchUsersQuery("Clone", 2); 
+
+            // Act
+            var result = await handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.Should().HaveCount(2);
+        }
+    }
+}

--- a/Community/Controllers/CommunityController.cs
+++ b/Community/Controllers/CommunityController.cs
@@ -22,6 +22,7 @@ using Rehla.Community.DTO.response;
 using BreastCancer.Community.DTO.response;
 using BreastCancer.Community.Features.Queries.GetUserPosts;
 using Swashbuckle.AspNetCore.Annotations;
+using BreastCancer.Community.Features.Queries.SearchUsers;
 
 namespace BreastCancer.Community.Controllers
 {
@@ -428,6 +429,45 @@ namespace BreastCancer.Community.Controllers
             catch (PostAccessForbiddenException ex)
             {
                 return StatusCode(StatusCodes.Status403Forbidden, new { message = ex.Message });
+            }
+        }
+
+        [HttpGet("users/search")]
+        [Authorize]
+        [SwaggerOperation(Summary = "Search users by name or email")]
+        [SwaggerResponse(StatusCodes.Status200OK, "Users retrieved successfully")]
+        [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized access")]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation error")]
+        public async Task<IActionResult> SearchUsers(
+           [FromQuery(Name = "query")] string searchTerm,
+           [FromQuery] int limit = 20,
+           CancellationToken cancellationToken = default)
+        {
+            var userId = User.GetUserId();
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return Unauthorized(new { message = "Could not identify user" });
+            }
+
+            if (string.IsNullOrWhiteSpace(searchTerm))
+            {
+                return BadRequest(new { message = "Search query cannot be empty" });
+            }
+
+            try
+            {
+                var users = await _mediator.Send(new SearchUsersQuery(searchTerm, limit), cancellationToken);
+
+                return Ok(users);
+            }
+            catch (ValidationException ex)
+            {
+                var errors = ex.Errors.Select(error => new
+                {
+                    field = error.PropertyName,
+                    message = error.ErrorMessage
+                });
+                return BadRequest(new { errors });
             }
         }
     }

--- a/Community/DTO/response/UserSearchDto.cs
+++ b/Community/DTO/response/UserSearchDto.cs
@@ -1,0 +1,4 @@
+﻿namespace BreastCancer.Community.DTO.response
+{
+    public record UserSearchDto(string Id, string Name, string Email, string AvatarUrl);
+}

--- a/Community/Features/Queries/SearchUsers/SearchUsersQuery.cs
+++ b/Community/Features/Queries/SearchUsers/SearchUsersQuery.cs
@@ -1,0 +1,7 @@
+﻿using BreastCancer.Community.DTO.response;
+using MediatR;
+
+namespace BreastCancer.Community.Features.Queries.SearchUsers
+{
+    public record SearchUsersQuery(string SearchTerm, int Limit = 20) : IRequest<List<UserSearchDto>>;
+}

--- a/Community/Features/Queries/SearchUsers/SearchUsersQueryHandler.cs
+++ b/Community/Features/Queries/SearchUsers/SearchUsersQueryHandler.cs
@@ -1,0 +1,45 @@
+﻿using BreastCancer.Community.DTO.response;
+using BreastCancer.Context;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace BreastCancer.Community.Features.Queries.SearchUsers
+{
+    public class SearchUsersQueryHandler : IRequestHandler<SearchUsersQuery, List<UserSearchDto>>
+    {
+        private readonly BreastCancerDB _context;
+
+        public SearchUsersQueryHandler(BreastCancerDB context)
+        {
+            _context = context;
+        }
+
+        public async Task<List<UserSearchDto>> Handle(SearchUsersQuery request, CancellationToken cancellationToken)
+        {
+            var query = _context.Users.AsNoTracking();
+
+            if (!string.IsNullOrWhiteSpace(request.SearchTerm))
+            {
+                var term = request.SearchTerm.Trim();
+
+                query = query.Where(u =>
+                    u.Id == term || 
+                    (u.FirstName + " " + u.LastName).Contains(term) ||
+                    u.Email.Contains(term));
+            }
+
+            var users = await query
+                .OrderBy(u => u.FirstName)
+                .ThenBy(u => u.LastName)
+                .Take(request.Limit)
+                .Select(u => new UserSearchDto(
+                    u.Id,
+                    u.FirstName + " " + u.LastName,
+                    u.Email,
+                    u.ImageUrl))
+                .ToListAsync(cancellationToken);
+
+            return users;
+        }
+    }
+}


### PR DESCRIPTION
Closes: #155

**Overview**
Implements the ability for users to search for other community members to facilitate better networking and connection within the community. The search is optimized for performance by using `AsNoTracking()` and explicit SQL projection to ensure efficient database queries.

**Acceptance Criteria Met**

* Added `GET /community/users/search` to allow querying by name, email, or exact ID.
* Implemented backend logic to match against User ID (exact), First/Last Name (contains), and Email (contains).
* Returns a lightweight `UserSearchDto` for optimized payload size.
* Enforced security: Endpoint requires valid authentication.
* RESTful standards: Returns `200 OK` with an empty list `[]` when no users match; does not return `404`.

**Technical Highlights**

* **EF Core Optimization:** Resolved the LINQ translation issue for the `FullName` field by concatenating `FirstName` and `LastName` directly in the query, ensuring the operation is performed on the database side rather than in-memory.
* **Pagination:** Included a `limit` parameter to prevent over-fetching.
* **Clean Architecture:** Fully integrated into the existing MediatR pipeline.

**Testing**

* **Unit Tests:** Verified search logic accuracy for name, email, and ID variations, as well as pagination limits.
* **Integration Tests:** Implemented full HTTP test suite covering unauthorized access, validation errors, empty results, and successful user retrieval.