### PR TITLE
fix: resolve posts author mapping and cross-user post visibility

### DIFF
--- a/Community/DTO/response/PostDTO.cs
+++ b/Community/DTO/response/PostDTO.cs
@@ -8,7 +8,6 @@ namespace BreastCancer.Community.DTO.response
         public int Id { get; set; }
         public string Content { get; set; }
         public PostType PostType { get; set; }
-        public List<string>? ImageUrl { get; set; } = new();
         public string AuthorId { get; set; } = null!;
         public string AuthorName { get; set; } = null!;
         public string? AuthorAvatarUrl { get; set; }

--- a/Community/Features/Commands/CreatePost/CreatePostCommandHandler.cs
+++ b/Community/Features/Commands/CreatePost/CreatePostCommandHandler.cs
@@ -4,6 +4,7 @@ using BreastCancer.Community.Events;
 using BreastCancer.Community.Events.Models;
 using BreastCancer.Community.Exceptions;
 using BreastCancer.Community.Services.Interface;
+using BreastCancer.Context;
 using BreastCancer.Enum;
 using BreastCancer.Models;
 using BreastCancer.Repository.Interface;
@@ -17,14 +18,17 @@ public sealed class CreatePostCommandHandler : IRequestHandler<CreatePostCommand
     private readonly IMapper _mapper;
     private readonly IPublisher _publisher;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly BreastCancerDB _dbContext;
+
     private readonly ICacheService _cacheService;
 
-    public CreatePostCommandHandler(IMapper mapper, IPublisher publisher, IUnitOfWork unitOfWork, ICacheService cacheService)
+    public CreatePostCommandHandler(IMapper mapper, IPublisher publisher, IUnitOfWork unitOfWork, ICacheService cacheService, BreastCancerDB dbContext)
     {
         _mapper = mapper;
         _publisher = publisher;
         _unitOfWork = unitOfWork;
         _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
     }
 
     public async Task<PostDTO> Handle(CreatePostCommand request, CancellationToken cancellationToken)
@@ -40,8 +44,11 @@ public sealed class CreatePostCommandHandler : IRequestHandler<CreatePostCommand
                 throw new PostAccessForbiddenException("Only doctors can create DoctorUpdate posts.");
             }
 
+            var author = await GetUserAsync(request.AuthorId);
+
             post = _mapper.Map<Post>(request.Post);
             post.AuthorId = request.AuthorId;
+            post.Author = author;
             post.MediaUrls = request.Post.MediaUrls ?? new List<string>();
 
             await _unitOfWork.PostRepository.AddAsync(post);
@@ -61,11 +68,25 @@ public sealed class CreatePostCommandHandler : IRequestHandler<CreatePostCommand
         }
 
         var dto = _mapper.Map<PostDTO>(post);
+        // dto.AuthorName = post.Author?.FullName;
+        // dto.MediaUrls = post.MediaUrls;
+        // dto.AuthorAvatarUrl = post.Author?.ImageUrl;
+        dto.AuthorRole = request.Roles.FirstOrDefault();
         await _cacheService.SetAsync(BuildPostCacheKey(post.Id), dto, TimeSpan.FromHours(1), cancellationToken);
 
         await _publisher.Publish(new PostCreatedEvent(post.Id, post.AuthorId, post.Visibility), cancellationToken);
 
         return dto;
+    }
+
+    private async Task<ApplicationUser> GetUserAsync(string userId)
+    {
+        var user = await _dbContext.Users.FindAsync(userId);
+        if (user == null)
+        {
+            throw new UserNotFoundException($"User with ID {userId} not found.");
+        }
+        return user;
     }
 
     private static string BuildPostCacheKey(int postId) => "post:" + postId;

--- a/Community/Features/Queries/GetFeed/GetFeedQueryHandler.cs
+++ b/Community/Features/Queries/GetFeed/GetFeedQueryHandler.cs
@@ -1,3 +1,5 @@
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
 using BreastCancer.Community.DTO.response;
 using BreastCancer.Community.Services.Interface;
 using BreastCancer.Context;
@@ -19,17 +21,20 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
     private readonly BreastCancerDB _dbContext;
     private readonly ICacheService _cacheService;
     private readonly ILogger<GetFeedQueryHandler> _logger;
+    private readonly IMapper _mapper;
 
     public GetFeedQueryHandler(
         IConnectionMultiplexer connectionMultiplexer,
         BreastCancerDB dbContext,
         ICacheService cacheService,
-        ILogger<GetFeedQueryHandler> logger)
+        ILogger<GetFeedQueryHandler> logger,
+        IMapper mapper)
     {
         _connectionMultiplexer = connectionMultiplexer ?? throw new ArgumentNullException(nameof(connectionMultiplexer));
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
 
     public async Task<FeedResponseDto> Handle(GetFeedQuery request, CancellationToken cancellationToken)
@@ -160,20 +165,8 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
         {
             var postsFromDb = await _dbContext.Posts
                 .AsNoTracking()
-                .Include(p => p.Author)
                 .Where(p => missedIds.Contains(p.Id) && !p.IsDeleted)
-                .Select(p => new PostDTO
-                {
-                    Id = p.Id,
-                    AuthorId = p.AuthorId,
-                    Content = p.Content,
-                    PostType = p.Type,
-                    PostVisibility = p.Visibility,
-                    MediaUrls = p.MediaUrls,
-                    CreatedAt = p.CreatedAt,
-                    UpdatedAt = p.UpdatedAt,
-                    IsEdited = p.IsEdited
-                })
+                .ProjectTo<PostDTO>(_mapper.ConfigurationProvider, new { currentUserId = userId ?? string.Empty })
                 .ToListAsync(cancellationToken);
 
             foreach (var post in postsFromDb)
@@ -202,7 +195,6 @@ public sealed class GetFeedQueryHandler : IRequestHandler<GetFeedQuery, FeedResp
             .Select(id => results[id])
             .ToList();
     }
-
     private static FeedResponseDto BuildResponse(List<PostDTO> hydratedPosts, int normalizedLimit)
     {
         var page = hydratedPosts.Take(normalizedLimit).ToList();

--- a/Community/Features/Queries/GetPost/GetPostQueryHandler.cs
+++ b/Community/Features/Queries/GetPost/GetPostQueryHandler.cs
@@ -24,6 +24,7 @@ public sealed class GetPostQueryHandler : IRequestHandler<GetPostQuery, PostDTO>
     public async Task<PostDTO> Handle(GetPostQuery request, CancellationToken cancellationToken)
     {
         var post = await _dbContext.Posts.AsNoTracking()
+            .Include(p => p.Author)
             .FirstOrDefaultAsync(p => p.Id == request.PostId && !p.IsDeleted, cancellationToken);
 
         if (post is null)

--- a/Community/Features/Queries/GetUserPosts/GetUserPostsQueryHandler.cs
+++ b/Community/Features/Queries/GetUserPosts/GetUserPostsQueryHandler.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
 using BreastCancer.Community.DTO.response;
 using BreastCancer.Community.Exceptions;
 using BreastCancer.Community.Services.Interface;
@@ -9,38 +11,39 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BreastCancer.Community.Features.Queries.GetUserPosts;
 
-public class GetUserPostsQueryHandler : IRequestHandler<GetUserPostsQuery,UserPostsResponseDto>
+public class GetUserPostsQueryHandler : IRequestHandler<GetUserPostsQuery, UserPostsResponseDto>
 {
     private readonly BreastCancerDB _context;
     private readonly IPostVisibilityService _postVisibilityService;
-    public GetUserPostsQueryHandler(BreastCancerDB context,IPostVisibilityService postVisibilityService)
+    private readonly IMapper _mapper;
+
+    public GetUserPostsQueryHandler(
+        BreastCancerDB context, 
+        IPostVisibilityService postVisibilityService,
+        IMapper mapper)
     {
-        this._context = context;
-        this._postVisibilityService = postVisibilityService;
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _postVisibilityService = postVisibilityService ?? throw new ArgumentNullException(nameof(postVisibilityService));
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
+
     public async Task<UserPostsResponseDto> Handle(GetUserPostsQuery request, CancellationToken cancellationToken)
     {
         var userExists = await _context.Users
             .AsNoTracking()
             .AnyAsync(u => u.Id == request.UserId, cancellationToken);
+            
         if (!userExists)
         {
             throw new NotFoundException($"User with ID '{request.UserId}' was not found");
         }
         
         int limit = Math.Clamp(request.Limit, 1, 50);
+        
         IQueryable<Post> postsQuery = _context.Posts
             .AsNoTracking()
             .Include(p => p.Author)
-                .ThenInclude(a => a.Patient)
-            .Include(p => p.Author)
-                .ThenInclude(a => a.Doctor)
-            .Include(p => p.Author)
-                .ThenInclude(a => a.Caregiver)
-            .Include(p => p.Reactions)
-            .Include(p => p.Comments.Where(c => !c.IsDeleted))
-            .Where(p => p.AuthorId == request.UserId)
-            .Where(p => !p.IsDeleted)
+            .Where(p => p.AuthorId == request.UserId && !p.IsDeleted)   
             .OrderByDescending(p => p.CreatedAt);
 
         bool isViewingOwnPosts = request.CurrentUserId == request.UserId;
@@ -51,72 +54,32 @@ public class GetUserPostsQueryHandler : IRequestHandler<GetUserPostsQuery,UserPo
                 .ApplyVisibilityFilterAsync(postsQuery, request.CurrentUserId, cancellationToken);
         }
 
-        if (!string.IsNullOrEmpty(request.Cursor))
+        if (!string.IsNullOrEmpty(request.Cursor) && 
+            DateTimeOffset.TryParseExact(request.Cursor, "o", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var cursorDate))
         {
-            if (DateTimeOffset
-                .TryParseExact(request.Cursor,"o" ,CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind,
-                    out var cursorDate)
-               )
-            {
-                var cursorUtc = cursorDate.UtcDateTime;
-                postsQuery = postsQuery.Where(p => p.CreatedAt < cursorUtc);
-            }
+            var cursorUtc = cursorDate.UtcDateTime;
+            postsQuery = postsQuery.Where(p => p.CreatedAt < cursorUtc);
         }
 
-        var postsData = await postsQuery.Take(limit + 1)
-            .Select(p => new
-            {
-                p.Id,
-                p.Content,
-                p.Type,
-                p.MediaUrls,
-                p.CreatedAt,
-                p.UpdatedAt,
-                p.AuthorId,
-                p.Visibility,
-                AuthorName = p.Author.FullName,
-                AuthorAvatarUrl = p.Author.ImageUrl,
-                AuthorRole = p.Author.Patient != null ? "Patient" : p.Author.Doctor != null ? "Doctor" : p.Author.Caregiver != null ? "Caregiver" : "Unknown",
-                ReactionsCount = p.Reactions.Count,
-                CommentsCount = p.Comments.Count(c=> !c.IsDeleted),
-                IsLikedByCurrentUser = !string.IsNullOrEmpty(request.CurrentUserId) && p.Reactions.Any(r => r.UserId == request.CurrentUserId),
-                IsEdited = p.UpdatedAt != null && p.UpdatedAt > p.CreatedAt
-            }).ToListAsync(cancellationToken);
-        var totalCount =  await postsQuery.CountAsync(cancellationToken);
+        var totalCount = await postsQuery.CountAsync(cancellationToken);
         
+        var postsData = await postsQuery
+            .Take(limit + 1)
+            .ProjectTo<PostDTO>(_mapper.ConfigurationProvider, new { currentUserId = request.CurrentUserId ?? string.Empty })
+            .ToListAsync(cancellationToken);
         
         string? nextCursor = null;
         bool hasMorePosts = postsData.Count > limit;
 
         if (hasMorePosts)
         {
-            nextCursor = new DateTimeOffset(postsData[limit-1].CreatedAt, TimeSpan.Zero).ToString("o");
+            nextCursor = new DateTimeOffset(postsData[limit - 1].CreatedAt, TimeSpan.Zero).ToString("o");
             postsData.RemoveAt(limit);
-
         }
-
-        var posts = postsData.Select(p => new PostDTO
-        {
-            Id = p.Id,
-            Content = p.Content,
-            PostType = p.Type,
-            MediaUrls = p.MediaUrls,
-            AuthorId = p.AuthorId,
-            AuthorName = p.AuthorName,
-            AuthorAvatarUrl = p.AuthorAvatarUrl,
-            AuthorRole = p.AuthorRole,
-            PostVisibility = p.Visibility,
-            ReactionsCount = p.ReactionsCount,
-            CommentsCount = p.CommentsCount,
-            IsLikedByCurrentUser = p.IsLikedByCurrentUser,
-            CreatedAt = p.CreatedAt,
-            UpdatedAt = p.UpdatedAt,
-            IsEdited = p.IsEdited
-        }).ToList();
 
         return new UserPostsResponseDto
         {
-            Posts = posts,
+            Posts = postsData,
             NextCursor = nextCursor,
             Total = totalCount
         };

--- a/Community/Features/Queries/GetUserPosts/GetUserPostsQueryHandler.cs
+++ b/Community/Features/Queries/GetUserPosts/GetUserPostsQueryHandler.cs
@@ -46,14 +46,6 @@ public class GetUserPostsQueryHandler : IRequestHandler<GetUserPostsQuery, UserP
             .Where(p => p.AuthorId == request.UserId && !p.IsDeleted)   
             .OrderByDescending(p => p.CreatedAt);
 
-        bool isViewingOwnPosts = request.CurrentUserId == request.UserId;
-
-        if (!isViewingOwnPosts)
-        {
-            postsQuery = await _postVisibilityService
-                .ApplyVisibilityFilterAsync(postsQuery, request.CurrentUserId, cancellationToken);
-        }
-
         if (!string.IsNullOrEmpty(request.Cursor) && 
             DateTimeOffset.TryParseExact(request.Cursor, "o", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var cursorDate))
         {

--- a/Community/Features/Queries/GetUserPosts/GetUserPostsQueryHandler.cs
+++ b/Community/Features/Queries/GetUserPosts/GetUserPostsQueryHandler.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
 using BreastCancer.Community.DTO.response;
 using BreastCancer.Community.Exceptions;
 using BreastCancer.Community.Services.Interface;
@@ -9,30 +11,39 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BreastCancer.Community.Features.Queries.GetUserPosts;
 
-public class GetUserPostsQueryHandler : IRequestHandler<GetUserPostsQuery,UserPostsResponseDto>
+public class GetUserPostsQueryHandler : IRequestHandler<GetUserPostsQuery, UserPostsResponseDto>
 {
     private readonly BreastCancerDB _context;
     private readonly IPostVisibilityService _postVisibilityService;
-    public GetUserPostsQueryHandler(BreastCancerDB context,IPostVisibilityService postVisibilityService)
+    private readonly IMapper _mapper;
+
+    public GetUserPostsQueryHandler(
+        BreastCancerDB context, 
+        IPostVisibilityService postVisibilityService,
+        IMapper mapper)
     {
-        this._context = context;
-        this._postVisibilityService = postVisibilityService;
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _postVisibilityService = postVisibilityService ?? throw new ArgumentNullException(nameof(postVisibilityService));
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
+
     public async Task<UserPostsResponseDto> Handle(GetUserPostsQuery request, CancellationToken cancellationToken)
     {
         var userExists = await _context.Users
             .AsNoTracking()
             .AnyAsync(u => u.Id == request.UserId, cancellationToken);
+            
         if (!userExists)
         {
             throw new NotFoundException($"User with ID '{request.UserId}' was not found");
         }
         
         int limit = Math.Clamp(request.Limit, 1, 50);
+        
         IQueryable<Post> postsQuery = _context.Posts
             .AsNoTracking()
-            .Where(p => p.AuthorId == request.UserId)
-            .Where(p => !p.IsDeleted)   
+            .Include(p => p.Author)
+            .Where(p => p.AuthorId == request.UserId && !p.IsDeleted)   
             .OrderByDescending(p => p.CreatedAt);
 
         bool isViewingOwnPosts = request.CurrentUserId == request.UserId;
@@ -43,72 +54,32 @@ public class GetUserPostsQueryHandler : IRequestHandler<GetUserPostsQuery,UserPo
                 .ApplyVisibilityFilterAsync(postsQuery, request.CurrentUserId, cancellationToken);
         }
 
-        if (!string.IsNullOrEmpty(request.Cursor))
+        if (!string.IsNullOrEmpty(request.Cursor) && 
+            DateTimeOffset.TryParseExact(request.Cursor, "o", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var cursorDate))
         {
-            if (DateTimeOffset
-                .TryParseExact(request.Cursor,"o" ,CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind,
-                    out var cursorDate)
-               )
-            {
-                var cursorUtc = cursorDate.UtcDateTime;
-                postsQuery = postsQuery.Where(p => p.CreatedAt < cursorUtc);
-            }
+            var cursorUtc = cursorDate.UtcDateTime;
+            postsQuery = postsQuery.Where(p => p.CreatedAt < cursorUtc);
         }
 
-        var postsData = await postsQuery.Take(limit + 1)
-            .Select(p => new
-            {
-                p.Id,
-                p.Content,
-                p.Type,
-                p.MediaUrls,
-                p.CreatedAt,
-                p.UpdatedAt,
-                p.AuthorId,
-                p.Visibility,
-                AuthorName = p.Author.FullName,
-                AuthorAvatarUrl = p.Author.ImageUrl,
-                AuthorRole = p.Author.Patient != null ? "Patient" : p.Author.Doctor != null ? "Doctor" : p.Author.Caregiver != null ? "Caregiver" : "Unknown",
-                ReactionsCount = p.Reactions.Count,
-                CommentsCount = p.Comments.Count(c=> !c.IsDeleted),
-                IsLikedByCurrentUser = !string.IsNullOrEmpty(request.CurrentUserId) && p.Reactions.Any(r => r.UserId == request.CurrentUserId),
-                IsEdited = p.UpdatedAt != null && p.UpdatedAt > p.CreatedAt
-            }).ToListAsync(cancellationToken);
-        var totalCount =  await postsQuery.CountAsync(cancellationToken);
+        var totalCount = await postsQuery.CountAsync(cancellationToken);
         
+        var postsData = await postsQuery
+            .Take(limit + 1)
+            .ProjectTo<PostDTO>(_mapper.ConfigurationProvider, new { currentUserId = request.CurrentUserId ?? string.Empty })
+            .ToListAsync(cancellationToken);
         
         string? nextCursor = null;
         bool hasMorePosts = postsData.Count > limit;
 
         if (hasMorePosts)
         {
-            nextCursor = new DateTimeOffset(postsData[limit-1].CreatedAt, TimeSpan.Zero).ToString("o");
+            nextCursor = new DateTimeOffset(postsData[limit - 1].CreatedAt, TimeSpan.Zero).ToString("o");
             postsData.RemoveAt(limit);
-
         }
-
-        var posts = postsData.Select(p => new PostDTO
-        {
-            Id = p.Id,
-            Content = p.Content,
-            PostType = p.Type,
-            ImageUrl = p.MediaUrls,
-            AuthorId = p.AuthorId,
-            AuthorName = p.AuthorName,
-            AuthorAvatarUrl = p.AuthorAvatarUrl,
-            AuthorRole = p.AuthorRole,
-            PostVisibility = p.Visibility,
-            ReactionsCount = p.ReactionsCount,
-            CommentsCount = p.CommentsCount,
-            IsLikedByCurrentUser = p.IsLikedByCurrentUser,
-            CreatedAt = p.CreatedAt,
-            UpdatedAt = p.UpdatedAt,
-            IsEdited = p.IsEdited
-        }).ToList();
 
         return new UserPostsResponseDto
         {
-            Posts = posts,
+            Posts = postsData,
             NextCursor = nextCursor,
             Total = totalCount
         };

--- a/Community/Features/Queries/GetUserPosts/GetUserPostsQueryHandler.cs
+++ b/Community/Features/Queries/GetUserPosts/GetUserPostsQueryHandler.cs
@@ -1,6 +1,4 @@
 using System.Globalization;
-using AutoMapper;
-using AutoMapper.QueryableExtensions;
 using BreastCancer.Community.DTO.response;
 using BreastCancer.Community.Exceptions;
 using BreastCancer.Community.Services.Interface;
@@ -11,39 +9,38 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BreastCancer.Community.Features.Queries.GetUserPosts;
 
-public class GetUserPostsQueryHandler : IRequestHandler<GetUserPostsQuery, UserPostsResponseDto>
+public class GetUserPostsQueryHandler : IRequestHandler<GetUserPostsQuery,UserPostsResponseDto>
 {
     private readonly BreastCancerDB _context;
     private readonly IPostVisibilityService _postVisibilityService;
-    private readonly IMapper _mapper;
-
-    public GetUserPostsQueryHandler(
-        BreastCancerDB context, 
-        IPostVisibilityService postVisibilityService,
-        IMapper mapper)
+    public GetUserPostsQueryHandler(BreastCancerDB context,IPostVisibilityService postVisibilityService)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
-        _postVisibilityService = postVisibilityService ?? throw new ArgumentNullException(nameof(postVisibilityService));
-        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        this._context = context;
+        this._postVisibilityService = postVisibilityService;
     }
-
     public async Task<UserPostsResponseDto> Handle(GetUserPostsQuery request, CancellationToken cancellationToken)
     {
         var userExists = await _context.Users
             .AsNoTracking()
             .AnyAsync(u => u.Id == request.UserId, cancellationToken);
-            
         if (!userExists)
         {
             throw new NotFoundException($"User with ID '{request.UserId}' was not found");
         }
         
         int limit = Math.Clamp(request.Limit, 1, 50);
-        
         IQueryable<Post> postsQuery = _context.Posts
             .AsNoTracking()
             .Include(p => p.Author)
-            .Where(p => p.AuthorId == request.UserId && !p.IsDeleted)   
+                .ThenInclude(a => a.Patient)
+            .Include(p => p.Author)
+                .ThenInclude(a => a.Doctor)
+            .Include(p => p.Author)
+                .ThenInclude(a => a.Caregiver)
+            .Include(p => p.Reactions)
+            .Include(p => p.Comments.Where(c => !c.IsDeleted))
+            .Where(p => p.AuthorId == request.UserId)
+            .Where(p => !p.IsDeleted)
             .OrderByDescending(p => p.CreatedAt);
 
         bool isViewingOwnPosts = request.CurrentUserId == request.UserId;
@@ -54,32 +51,72 @@ public class GetUserPostsQueryHandler : IRequestHandler<GetUserPostsQuery, UserP
                 .ApplyVisibilityFilterAsync(postsQuery, request.CurrentUserId, cancellationToken);
         }
 
-        if (!string.IsNullOrEmpty(request.Cursor) && 
-            DateTimeOffset.TryParseExact(request.Cursor, "o", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var cursorDate))
+        if (!string.IsNullOrEmpty(request.Cursor))
         {
-            var cursorUtc = cursorDate.UtcDateTime;
-            postsQuery = postsQuery.Where(p => p.CreatedAt < cursorUtc);
+            if (DateTimeOffset
+                .TryParseExact(request.Cursor,"o" ,CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind,
+                    out var cursorDate)
+               )
+            {
+                var cursorUtc = cursorDate.UtcDateTime;
+                postsQuery = postsQuery.Where(p => p.CreatedAt < cursorUtc);
+            }
         }
 
-        var totalCount = await postsQuery.CountAsync(cancellationToken);
+        var postsData = await postsQuery.Take(limit + 1)
+            .Select(p => new
+            {
+                p.Id,
+                p.Content,
+                p.Type,
+                p.MediaUrls,
+                p.CreatedAt,
+                p.UpdatedAt,
+                p.AuthorId,
+                p.Visibility,
+                AuthorName = p.Author.FullName,
+                AuthorAvatarUrl = p.Author.ImageUrl,
+                AuthorRole = p.Author.Patient != null ? "Patient" : p.Author.Doctor != null ? "Doctor" : p.Author.Caregiver != null ? "Caregiver" : "Unknown",
+                ReactionsCount = p.Reactions.Count,
+                CommentsCount = p.Comments.Count(c=> !c.IsDeleted),
+                IsLikedByCurrentUser = !string.IsNullOrEmpty(request.CurrentUserId) && p.Reactions.Any(r => r.UserId == request.CurrentUserId),
+                IsEdited = p.UpdatedAt != null && p.UpdatedAt > p.CreatedAt
+            }).ToListAsync(cancellationToken);
+        var totalCount =  await postsQuery.CountAsync(cancellationToken);
         
-        var postsData = await postsQuery
-            .Take(limit + 1)
-            .ProjectTo<PostDTO>(_mapper.ConfigurationProvider, new { currentUserId = request.CurrentUserId ?? string.Empty })
-            .ToListAsync(cancellationToken);
         
         string? nextCursor = null;
         bool hasMorePosts = postsData.Count > limit;
 
         if (hasMorePosts)
         {
-            nextCursor = new DateTimeOffset(postsData[limit - 1].CreatedAt, TimeSpan.Zero).ToString("o");
+            nextCursor = new DateTimeOffset(postsData[limit-1].CreatedAt, TimeSpan.Zero).ToString("o");
             postsData.RemoveAt(limit);
+
         }
+
+        var posts = postsData.Select(p => new PostDTO
+        {
+            Id = p.Id,
+            Content = p.Content,
+            PostType = p.Type,
+            MediaUrls = p.MediaUrls,
+            AuthorId = p.AuthorId,
+            AuthorName = p.AuthorName,
+            AuthorAvatarUrl = p.AuthorAvatarUrl,
+            AuthorRole = p.AuthorRole,
+            PostVisibility = p.Visibility,
+            ReactionsCount = p.ReactionsCount,
+            CommentsCount = p.CommentsCount,
+            IsLikedByCurrentUser = p.IsLikedByCurrentUser,
+            CreatedAt = p.CreatedAt,
+            UpdatedAt = p.UpdatedAt,
+            IsEdited = p.IsEdited
+        }).ToList();
 
         return new UserPostsResponseDto
         {
-            Posts = postsData,
+            Posts = posts,
             NextCursor = nextCursor,
             Total = totalCount
         };

--- a/Community/Features/Queries/GetUserPosts/GetUserPostsQueryHandler.cs
+++ b/Community/Features/Queries/GetUserPosts/GetUserPostsQueryHandler.cs
@@ -46,6 +46,14 @@ public class GetUserPostsQueryHandler : IRequestHandler<GetUserPostsQuery, UserP
             .Where(p => p.AuthorId == request.UserId && !p.IsDeleted)   
             .OrderByDescending(p => p.CreatedAt);
 
+        bool isViewingOwnPosts = request.CurrentUserId == request.UserId;
+
+        if (!isViewingOwnPosts)
+        {
+            postsQuery = await _postVisibilityService
+                .ApplyVisibilityFilterAsync(postsQuery, request.CurrentUserId, cancellationToken);
+        }
+
         if (!string.IsNullOrEmpty(request.Cursor) && 
             DateTimeOffset.TryParseExact(request.Cursor, "o", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var cursorDate))
         {

--- a/Community/Features/Queries/GetUserPosts/GetUserPostsQueryHandler.cs
+++ b/Community/Features/Queries/GetUserPosts/GetUserPostsQueryHandler.cs
@@ -43,7 +43,15 @@ public class GetUserPostsQueryHandler : IRequestHandler<GetUserPostsQuery, UserP
         IQueryable<Post> postsQuery = _context.Posts
             .AsNoTracking()
             .Include(p => p.Author)
-            .Where(p => p.AuthorId == request.UserId && !p.IsDeleted)   
+                .ThenInclude(a => a.Patient)
+            .Include(p => p.Author)
+                .ThenInclude(a => a.Doctor)
+            .Include(p => p.Author)
+                .ThenInclude(a => a.Caregiver)
+            .Include(p => p.Reactions)
+            .Include(p => p.Comments.Where(c => !c.IsDeleted))
+            .Where(p => p.AuthorId == request.UserId)
+            .Where(p => !p.IsDeleted)  
             .OrderByDescending(p => p.CreatedAt);
 
         bool isViewingOwnPosts = request.CurrentUserId == request.UserId;

--- a/Community/Services/Implementation/PostVisibilityService.cs
+++ b/Community/Services/Implementation/PostVisibilityService.cs
@@ -15,22 +15,25 @@ public class PostVisibilityService :IPostVisibilityService
     }
     
     public async Task<IQueryable<Post>> ApplyVisibilityFilterAsync(
-        IQueryable<Post> query,
-        string? currentUserId, 
-        CancellationToken cancellationToken=default)
+    IQueryable<Post> query,
+    string? currentUserId, 
+    CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(currentUserId))
             return query.Where(post => post.Visibility == PostVisibility.Public);
 
         var userContext = await GetUserContextAsync(currentUserId, cancellationToken);
         var followingIds = userContext.FollowingIds;
+        var role = userContext.Role;
 
-        return query.Where(
-            post => post.AuthorId == currentUserId ||
-            IsVisibleByRole(post.Visibility,userContext.Role) || 
+        return query.Where(post =>
+            post.AuthorId == currentUserId ||
+            post.Visibility == PostVisibility.Public ||
+            (post.Visibility == PostVisibility.DoctorOnly && role == "Doctor") ||
+            (post.Visibility == PostVisibility.PatientsOnly && role == "Patient") ||
+            (post.Visibility == PostVisibility.CaregiverOnly && role == "Caregiver") ||
             (post.Visibility == PostVisibility.FollowersOnly && followingIds.Contains(post.AuthorId))
         );
-
     }
 
     public async Task<bool> IsPostVisibleAsync(Post post, string? currentUserId, CancellationToken cancellationToken = default)

--- a/Community/Services/Implementation/PostVisibilityService.cs
+++ b/Community/Services/Implementation/PostVisibilityService.cs
@@ -15,25 +15,22 @@ public class PostVisibilityService :IPostVisibilityService
     }
     
     public async Task<IQueryable<Post>> ApplyVisibilityFilterAsync(
-    IQueryable<Post> query,
-    string? currentUserId, 
-    CancellationToken cancellationToken = default)
+        IQueryable<Post> query,
+        string? currentUserId, 
+        CancellationToken cancellationToken=default)
     {
         if (string.IsNullOrEmpty(currentUserId))
             return query.Where(post => post.Visibility == PostVisibility.Public);
 
         var userContext = await GetUserContextAsync(currentUserId, cancellationToken);
         var followingIds = userContext.FollowingIds;
-        var role = userContext.Role;
 
-        return query.Where(post =>
-            post.AuthorId == currentUserId ||
-            post.Visibility == PostVisibility.Public ||
-            (post.Visibility == PostVisibility.DoctorOnly && role == "Doctor") ||
-            (post.Visibility == PostVisibility.PatientsOnly && role == "Patient") ||
-            (post.Visibility == PostVisibility.CaregiverOnly && role == "Caregiver") ||
+        return query.Where(
+            post => post.AuthorId == currentUserId ||
+            IsVisibleByRole(post.Visibility,userContext.Role) || 
             (post.Visibility == PostVisibility.FollowersOnly && followingIds.Contains(post.AuthorId))
         );
+
     }
 
     public async Task<bool> IsPostVisibleAsync(Post post, string? currentUserId, CancellationToken cancellationToken = default)

--- a/Community/Services/Implementation/PostVisibilityService.cs
+++ b/Community/Services/Implementation/PostVisibilityService.cs
@@ -24,13 +24,16 @@ public class PostVisibilityService :IPostVisibilityService
 
         var userContext = await GetUserContextAsync(currentUserId, cancellationToken);
         var followingIds = userContext.FollowingIds;
-
-        return query.Where(
-            post => post.AuthorId == currentUserId ||
-            IsVisibleByRole(post.Visibility,userContext.Role) || 
+        var role = userContext.Role;
+        
+        return query.Where(post =>
+            post.AuthorId == currentUserId ||
+            post.Visibility == PostVisibility.Public ||
+            (post.Visibility == PostVisibility.DoctorOnly && role == "Doctor") ||
+            (post.Visibility == PostVisibility.PatientsOnly && role == "Patient") ||
+            (post.Visibility == PostVisibility.CaregiverOnly && role == "Caregiver") ||
             (post.Visibility == PostVisibility.FollowersOnly && followingIds.Contains(post.AuthorId))
         );
-
     }
 
     public async Task<bool> IsPostVisibleAsync(Post post, string? currentUserId, CancellationToken cancellationToken = default)

--- a/Mapping/MappingProfile.cs
+++ b/Mapping/MappingProfile.cs
@@ -236,7 +236,10 @@ namespace BreastCancer.Mapping
                 .ForMember(dest => dest.PostVisibility, opt => opt.MapFrom(src => src.Visibility))
                 .ForMember(dest => dest.MediaUrls, opt => opt.MapFrom(src => src.MediaUrls))
                 .ForMember(dest => dest.UpdatedAt, opt => opt.MapFrom(src => src.UpdatedAt))
-                .ForMember(dest => dest.IsEdited, opt => opt.MapFrom(src => src.IsEdited));
+                .ForMember(dest => dest.IsEdited, opt => opt.MapFrom(src => src.IsEdited))
+                .ForMember(dest => dest.AuthorName, opt => opt.MapFrom(src => src.Author != null ? src.Author.FullName : null))
+                .ForMember(dest => dest.AuthorAvatarUrl, opt => opt.MapFrom(src => src.Author != null ? src.Author.ImageUrl : null))
+                .ForMember(dest => dest.AuthorRole, opt => opt.Ignore()); 
 
             #endregion
 


### PR DESCRIPTION
## Overview
This PR addresses two bugs within the Community module related to DTO mapping/caching and post visibility.

## Changes Made
- **Feed Endpoint:** Refactored `HydratePostsAsync` to properly project Author relations to the `PostDTO` before caching to Redis. This prevents the system from serving cached posts with null author fields.
- **User Posts Endpoint:** Corrected the logic handling cross-user viewing so that users can view other users' public posts.

Closes #160 